### PR TITLE
build(macos): make sysroot setup atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         run: tools/setup-ghostty-src.sh
       - name: Setup vendored ghostty themes
         run: tools/setup-themes.sh
+      - name: Setup macOS sysroot
+        run: tools/setup-sysroot.sh
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --workspace --all-targets
 
@@ -70,5 +72,7 @@ jobs:
         run: tools/setup-ghostty-src.sh
       - name: Setup vendored ghostty themes
         run: tools/setup-themes.sh
+      - name: Setup macOS sysroot
+        run: tools/setup-sysroot.sh
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 bash tools/setup-ghostty-src.sh >/dev/null
 bash tools/setup-themes.sh >/dev/null
+bash tools/setup-sysroot.sh >/dev/null
 PROFILE="${1:-release}"
 cargo build ${PROFILE:+--profile=$PROFILE} 2>/dev/null || cargo build --release
 bash tools/make-app.sh "$PROFILE" >/dev/null

--- a/tools/setup-sysroot.sh
+++ b/tools/setup-sysroot.sh
@@ -7,24 +7,43 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SYSROOT="$SCRIPT_DIR/sysroot"
 SDK_PATH="$(/usr/bin/xcrun --show-sdk-path)"
 ZIG_LIBC="$(zig env 2>/dev/null | grep lib_dir | head -1 | sed 's/.*"\(.*\)".*/\1/')/libc/darwin/libSystem.tbd"
-SDK_STAMP="$SYSROOT/.sdk-path"
 
 if [ ! -f "$ZIG_LIBC" ]; then
     echo "error: cannot find Zig's libSystem.tbd at $ZIG_LIBC" >&2
     exit 1
 fi
 
-rm -rf "$SYSROOT"
-mkdir -p "$SYSROOT/usr/lib" "$SYSROOT/usr/include"
+# Build into a staging dir then atomically rename, so concurrent invocations
+# (e.g. several rustc build-script links hitting tools/xcrun at once) never
+# observe a half-populated sysroot.
+STAGING="$SYSROOT.tmp.$$"
+trap 'rm -rf "$STAGING"' EXIT
+rm -rf "$STAGING"
+mkdir -p "$STAGING/usr/lib" "$STAGING/usr/include"
 
 # Symlink SDK contents.
-ln -sf "$SDK_PATH/usr/include"/* "$SYSROOT/usr/include/" 2>/dev/null || true
-ln -sf "$SDK_PATH/usr/lib"/* "$SYSROOT/usr/lib/" 2>/dev/null || true
-[ -d "$SDK_PATH/System" ] && ln -sf "$SDK_PATH/System" "$SYSROOT/System" 2>/dev/null || true
+ln -sf "$SDK_PATH/usr/include"/* "$STAGING/usr/include/" 2>/dev/null || true
+ln -sf "$SDK_PATH/usr/lib"/* "$STAGING/usr/lib/" 2>/dev/null || true
+[ -d "$SDK_PATH/System" ] && ln -sf "$SDK_PATH/System" "$STAGING/System"
+
+# Symlink SDK-root metadata (SDKSettings.plist, SDKSettings.json,
+# Entitlements.plist, Library/, ...). Newer Apple ld reads SDKSettings.plist
+# off the sysroot root to determine the SDK version.
+for entry in "$SDK_PATH"/*; do
+    name="$(basename "$entry")"
+    case "$name" in
+        usr|System) ;;
+        *) ln -sf "$entry" "$STAGING/$name" ;;
+    esac
+done
 
 # Replace libSystem.tbd with Zig's version (includes arm64-macos).
-rm -f "$SYSROOT/usr/lib/libSystem.tbd"
-cp "$ZIG_LIBC" "$SYSROOT/usr/lib/libSystem.tbd"
-printf '%s\n' "$SDK_PATH" > "$SDK_STAMP"
+rm -f "$STAGING/usr/lib/libSystem.tbd"
+cp "$ZIG_LIBC" "$STAGING/usr/lib/libSystem.tbd"
+printf '%s\n' "$SDK_PATH" > "$STAGING/.sdk-path"
+
+rm -rf "$SYSROOT"
+mv "$STAGING" "$SYSROOT"
+trap - EXIT
 
 echo "sysroot created at $SYSROOT"


### PR DESCRIPTION
## Summary
This PR improves the macOS sysroot setup process by making it atomic and including necessary SDK metadata files that newer Apple linkers require.

## Key Changes
- **Atomic sysroot creation**: Build the sysroot into a temporary staging directory and atomically rename it to the final location. This prevents concurrent invocations (e.g., multiple rustc build-script links) from observing a half-populated sysroot.
- **Include SDK metadata**: Symlink SDK-root metadata files (SDKSettings.plist, SDKSettings.json, Entitlements.plist, Library/, etc.) to the sysroot root, as newer Apple ld reads SDKSettings.plist to determine the SDK version.
- **Integrate into CI and build scripts**: Add `setup-sysroot.sh` invocation to GitHub Actions workflows and the local `run.sh` build script to ensure the sysroot is properly initialized.

## Implementation Details
- Uses a temporary staging directory (`$SYSROOT.tmp.$$`) with a trap handler to ensure cleanup on exit
- Preserves existing symlink behavior for `usr` and `System` directories while adding a loop to symlink other SDK-root entries
- Moves the SDK path stamp file into the staging directory before the atomic rename
- Removes the now-unused `SDK_STAMP` variable that tracked the stamp file location

https://claude.ai/code/session_01ShbrRkf43k6PPwUdoZm1Yn