### PR TITLE
feat(config): hot-reload config and themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +729,15 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-core"
@@ -934,6 +952,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "int-enum"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1111,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1251,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1338,46 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375bd3a138be7bfeff3480e4a623df4cbfb55b79df617c055cd810ba466fa078"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2054,6 +2164,8 @@ dependencies = [
  "arboard",
  "env_logger",
  "log",
+ "notify",
+ "notify-debouncer-full",
  "objc2 0.6.4",
  "pollster",
  "raw-window-handle",
@@ -2587,6 +2699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,7 +3208,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3099,7 +3217,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3117,14 +3244,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3143,10 +3287,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3155,10 +3311,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3167,10 +3335,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3179,10 +3359,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/crates/seance-app/Cargo.toml
+++ b/crates/seance-app/Cargo.toml
@@ -15,6 +15,8 @@ seance-input = { path = "../seance-input" }
 seance-render = { path = "../seance-render" }
 seance-vt = { path = "../seance-vt" }
 arboard = "3"
+notify = "8"
+notify-debouncer-full = "0.6"
 pollster = "0.4"
 log.workspace = true
 env_logger.workspace = true

--- a/crates/seance-app/src/main.rs
+++ b/crates/seance-app/src/main.rs
@@ -1,13 +1,14 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use winit::application::ApplicationHandler;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event::{ElementState, Modifiers, MouseButton, WindowEvent};
-use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use winit::window::{Window, WindowId};
 
-use seance_config::Config;
+use seance_config::{Config, ConfigDiff};
 use seance_input::{InputHandler, VtInput};
 use seance_render::{RenderInputs, RendererConfig, TerminalRenderer};
 use seance_vt::{LibGhosttyFrameSource, Terminal, TerminalModes};
@@ -15,9 +16,22 @@ use seance_vt::{LibGhosttyFrameSource, Terminal, TerminalModes};
 mod command;
 mod keybinds;
 mod platform;
+mod watcher;
 
 use command::AppCommand;
 use keybinds::Keybinds;
+use watcher::ConfigWatcher;
+
+/// Events forwarded from the config watcher into the winit event loop. Using
+/// `EventLoopProxy` keeps reloads single-threaded with rendering — no torn
+/// reads of `Config` mid-frame.
+#[derive(Debug, Clone)]
+pub enum UserEvent {
+    /// `config.toml` at `$XDG_CONFIG_HOME/seance/` changed.
+    ConfigFileChanged,
+    /// A file under `$XDG_CONFIG_HOME/seance/themes/` changed.
+    ThemeFileChanged(PathBuf),
+}
 
 const FONT_SIZE_MIN: f32 = 6.0;
 const FONT_SIZE_MAX: f32 = 72.0;
@@ -74,10 +88,12 @@ struct App {
     content_dirty: bool,
     occluded: bool,
     mouse: MouseState,
+    proxy: EventLoopProxy<UserEvent>,
+    watcher: Option<ConfigWatcher>,
 }
 
 impl App {
-    fn new(config: Config) -> Self {
+    fn new(config: Config, proxy: EventLoopProxy<UserEvent>) -> Self {
         let font_size = config.font.size;
         Self {
             window: None,
@@ -93,6 +109,8 @@ impl App {
             content_dirty: true,
             occluded: false,
             mouse: MouseState::default(),
+            proxy,
+            watcher: None,
         }
     }
 
@@ -158,6 +176,92 @@ impl App {
         if let (Some(r), Some(w)) = (&mut self.renderer, &self.window) {
             r.set_font_size(self.font_size);
             self.reflow(w.inner_size());
+        }
+    }
+
+    /// Re-resolve the currently-configured theme and push it to the renderer.
+    /// Bad theme files keep the previous theme live (#13).
+    fn reload_theme(&mut self) {
+        if self.renderer.is_none() {
+            return;
+        }
+        let spec = seance_config::theme::ThemeSpec::parse(
+            self.config
+                .theme
+                .as_deref()
+                .unwrap_or(seance_config::theme::resolve::DEFAULT_THEME_NAME),
+        );
+        let theme = match seance_config::theme::try_load(&spec) {
+            Ok(t) => t,
+            Err(err) => {
+                log::warn!("theme reload skipped: {err}");
+                return;
+            }
+        };
+        if let Some(r) = &mut self.renderer {
+            r.set_theme(theme);
+        }
+        self.mark_dirty();
+    }
+
+    /// Re-parse `config.toml` and apply whatever actually changed. A bad
+    /// TOML parse is logged and the running config is left untouched.
+    fn reload_config(&mut self) {
+        let Some(path) = seance_config::config_file_path() else {
+            return;
+        };
+        let new_config = match seance_config::try_load_from(&path) {
+            Ok(c) => c,
+            Err(err) => {
+                log::warn!("config reload skipped: {err}");
+                return;
+            }
+        };
+        let diff = ConfigDiff::between(&self.config, &new_config);
+        if diff.is_empty() {
+            self.config = new_config;
+            return;
+        }
+
+        log::info!("config reloaded: {diff:?}");
+        self.config = new_config;
+
+        if diff.font_size_changed {
+            self.font_size = self.config.font.size;
+            self.apply_font_size();
+        }
+        if diff.font_family_changed {
+            log::info!("font.family change takes effect on restart (live swap not yet supported)");
+        }
+        if diff.theme_changed {
+            self.reload_theme();
+        }
+        if diff.repaint_only {
+            self.mark_dirty();
+        }
+    }
+
+    /// A file under `themes/` changed on disk. Only re-resolve if it's the
+    /// theme actually in use (either a named override in the user dir or an
+    /// absolute-path spec pointing at that file).
+    fn on_theme_file_changed(&mut self, path: &std::path::Path) {
+        let active = self
+            .config
+            .theme
+            .as_deref()
+            .unwrap_or(seance_config::theme::resolve::DEFAULT_THEME_NAME);
+        let spec = seance_config::theme::ThemeSpec::parse(active);
+        let matches = match &spec {
+            seance_config::theme::ThemeSpec::Named(name)
+            | seance_config::theme::ThemeSpec::LightDark { dark: name, .. } => {
+                seance_config::config_dir()
+                    .map(|d| d.join("themes").join(name))
+                    .is_some_and(|p| p == path)
+            }
+            seance_config::theme::ThemeSpec::Path(p) => p == path,
+        };
+        if matches {
+            self.reload_theme();
         }
     }
 
@@ -342,7 +446,7 @@ impl App {
     }
 }
 
-impl ApplicationHandler for App {
+impl ApplicationHandler<UserEvent> for App {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if self.window.is_some() {
             return;
@@ -380,6 +484,21 @@ impl ApplicationHandler for App {
             Terminal::spawn(cols, rows, size.width as u16, size.height as u16)
                 .expect("failed to spawn terminal"),
         );
+
+        // Start watching the config dir for edits. A non-XDG environment or
+        // an unreadable dir just skips the watcher — seance keeps running.
+        if self.watcher.is_none()
+            && let Some(dir) = seance_config::config_dir()
+        {
+            self.watcher = ConfigWatcher::spawn(&dir, self.proxy.clone());
+        }
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: UserEvent) {
+        match event {
+            UserEvent::ConfigFileChanged => self.reload_config(),
+            UserEvent::ThemeFileChanged(path) => self.on_theme_file_changed(&path),
+        }
     }
 
     fn window_event(
@@ -425,14 +544,15 @@ impl ApplicationHandler for App {
 
 fn main() {
     env_logger::init();
-    let mut builder = EventLoop::builder();
+    let mut builder = EventLoop::<UserEvent>::with_user_event();
     #[cfg(target_os = "macos")]
     {
         use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
         builder.with_activation_policy(ActivationPolicy::Regular);
     }
     let event_loop = builder.build().expect("failed to create event loop");
+    let proxy = event_loop.create_proxy();
     let config = seance_config::load();
-    let mut app = App::new(config);
+    let mut app = App::new(config, proxy);
     event_loop.run_app(&mut app).expect("event loop failed");
 }

--- a/crates/seance-app/src/watcher.rs
+++ b/crates/seance-app/src/watcher.rs
@@ -1,0 +1,123 @@
+//! File watcher that forwards config/theme file changes into the winit event
+//! loop as [`UserEvent`]s.
+//!
+//! Owns a `notify-debouncer-full` debouncer with a 100ms window (per #13) —
+//! the background thread lives for the lifetime of [`ConfigWatcher`] and is
+//! torn down on drop.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use notify::{EventKind, RecursiveMode};
+use notify_debouncer_full::{Debouncer, RecommendedCache, new_debouncer};
+use winit::event_loop::EventLoopProxy;
+
+use crate::UserEvent;
+
+const DEBOUNCE: Duration = Duration::from_millis(100);
+const THEMES_SUBDIR: &str = "themes";
+
+/// Watches `$XDG_CONFIG_HOME/seance/` for edits to `config.toml` and anything
+/// under `themes/`. Dropped when the app exits.
+pub struct ConfigWatcher {
+    // RAII — debouncer owns a worker thread that stops on drop.
+    _debouncer: Debouncer<notify::RecommendedWatcher, RecommendedCache>,
+}
+
+impl ConfigWatcher {
+    /// Start watching `config_dir`. Fails silently (returns `None`) if the
+    /// directory cannot be watched — a missing config dir should never stop
+    /// the terminal from launching.
+    pub fn spawn(config_dir: &Path, proxy: EventLoopProxy<UserEvent>) -> Option<Self> {
+        let config_file = config_dir.join(seance_config::CONFIG_FILENAME);
+        let themes_dir = config_dir.join(THEMES_SUBDIR);
+        let config_dir_owned = config_dir.to_path_buf();
+
+        let handler = move |result: notify_debouncer_full::DebounceEventResult| match result {
+            Ok(events) => {
+                dispatch_events(&events, &config_file, &themes_dir, &proxy);
+            }
+            Err(errors) => {
+                for e in errors {
+                    log::warn!("config watcher error: {e}");
+                }
+            }
+        };
+
+        let mut debouncer = match new_debouncer(DEBOUNCE, None, handler) {
+            Ok(d) => d,
+            Err(err) => {
+                log::warn!("config watcher: could not create debouncer: {err}");
+                return None;
+            }
+        };
+
+        // Watch the parent dir non-recursively (catches atomic-save rename +
+        // delete/create of config.toml that most editors do) — the themes
+        // dir is watched recursively only if it exists on disk.
+        if let Err(err) = debouncer.watch(&config_dir_owned, RecursiveMode::NonRecursive) {
+            log::warn!(
+                "config watcher: could not watch {}: {err}",
+                config_dir_owned.display()
+            );
+            return None;
+        }
+        if themes_dir.is_dir() {
+            if let Err(err) = debouncer.watch(&themes_dir, RecursiveMode::Recursive) {
+                log::warn!(
+                    "config watcher: could not watch {}: {err}",
+                    themes_dir.display()
+                );
+            }
+        }
+
+        log::info!("config watcher: watching {}", config_dir_owned.display());
+        Some(Self {
+            _debouncer: debouncer,
+        })
+    }
+}
+
+fn dispatch_events(
+    events: &[notify_debouncer_full::DebouncedEvent],
+    config_file: &Path,
+    themes_dir: &Path,
+    proxy: &EventLoopProxy<UserEvent>,
+) {
+    // Collapse a burst into at most one ConfigFileChanged + one
+    // ThemeFileChanged(path) per distinct theme path.
+    let mut config_changed = false;
+    let mut theme_paths: Vec<PathBuf> = Vec::new();
+
+    for ev in events {
+        if !is_content_event(&ev.event.kind) {
+            continue;
+        }
+        for path in &ev.event.paths {
+            if path == config_file {
+                config_changed = true;
+            } else if path.starts_with(themes_dir) && !theme_paths.iter().any(|p| p == path) {
+                theme_paths.push(path.clone());
+            }
+        }
+    }
+
+    if config_changed {
+        // If the proxy send fails the event loop has already exited; the
+        // next drop will clean up the watcher thread.
+        let _ = proxy.send_event(UserEvent::ConfigFileChanged);
+    }
+    for path in theme_paths {
+        let _ = proxy.send_event(UserEvent::ThemeFileChanged(path));
+    }
+}
+
+/// True for events that might have changed the content of a file we care
+/// about. We skip pure metadata/access events to avoid reloading on every
+/// `stat()` touch.
+fn is_content_event(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) | EventKind::Any
+    )
+}

--- a/crates/seance-app/src/watcher.rs
+++ b/crates/seance-app/src/watcher.rs
@@ -29,17 +29,23 @@ impl ConfigWatcher {
     /// directory cannot be watched — a missing config dir should never stop
     /// the terminal from launching.
     pub fn spawn(config_dir: &Path, proxy: EventLoopProxy<UserEvent>) -> Option<Self> {
-        let config_file = config_dir.join(seance_config::CONFIG_FILENAME);
-        let themes_dir = config_dir.join(THEMES_SUBDIR);
         let config_dir_owned = config_dir.to_path_buf();
+        let themes_dir = config_dir_owned.join(THEMES_SUBDIR);
 
-        let handler = move |result: notify_debouncer_full::DebounceEventResult| match result {
-            Ok(events) => {
-                dispatch_events(&events, &config_file, &themes_dir, &proxy);
-            }
-            Err(errors) => {
-                for e in errors {
-                    log::warn!("config watcher error: {e}");
+        // The handler closure owns its own copies — everything after this
+        // line still needs `themes_dir` / `config_dir_owned` for watching
+        // and logging.
+        let handler = {
+            let config_file = config_dir_owned.join(seance_config::CONFIG_FILENAME);
+            let themes_dir = themes_dir.clone();
+            move |result: notify_debouncer_full::DebounceEventResult| match result {
+                Ok(events) => {
+                    dispatch_events(&events, &config_file, &themes_dir, &proxy);
+                }
+                Err(errors) => {
+                    for e in errors {
+                        log::warn!("config watcher error: {e}");
+                    }
                 }
             }
         };
@@ -62,13 +68,13 @@ impl ConfigWatcher {
             );
             return None;
         }
-        if themes_dir.is_dir() {
-            if let Err(err) = debouncer.watch(&themes_dir, RecursiveMode::Recursive) {
-                log::warn!(
-                    "config watcher: could not watch {}: {err}",
-                    themes_dir.display()
-                );
-            }
+        if themes_dir.is_dir()
+            && let Err(err) = debouncer.watch(&themes_dir, RecursiveMode::Recursive)
+        {
+            log::warn!(
+                "config watcher: could not watch {}: {err}",
+                themes_dir.display()
+            );
         }
 
         log::info!("config watcher: watching {}", config_dir_owned.display());

--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -1,0 +1,146 @@
+//! Config diff used by the hot-reload path (#13) to decide what to
+//! invalidate when the file on disk changes.
+//!
+//! Kept in this crate (rather than in `seance-app`) because it is a pure
+//! function of two [`Config`] values — no winit / wgpu dependency, so it is
+//! unit-testable in isolation.
+
+use crate::Config;
+
+/// Which subsystems a [`Config`] delta requires us to refresh.
+///
+/// Constructed via [`ConfigDiff::between`]. A freshly-parsed config equal to
+/// the old one produces an all-false diff, letting the caller skip work.
+///
+/// `font_family_changed` is surfaced separately from `font_size_changed`
+/// because changing the family requires rebuilding the whole font backend
+/// (not supported by the live renderer today — the app logs a notice telling
+/// the user to restart).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ConfigDiff {
+    /// `theme =` key changed — re-resolve and swap the palette.
+    pub theme_changed: bool,
+    /// `font.size` changed — `TerminalRenderer::set_font_size` handles this
+    /// (clears glyph atlas, recomputes cell metrics).
+    pub font_size_changed: bool,
+    /// `font.family` changed — live reload not yet implemented; caller logs
+    /// a notice.
+    pub font_family_changed: bool,
+    /// Cursor/padding/opacity/mouse-hide changed — a plain repaint is enough
+    /// (downstream consumers read `Config` directly on the next frame).
+    pub repaint_only: bool,
+}
+
+impl ConfigDiff {
+    /// Compute what changed between `old` and `new`.
+    pub fn between(old: &Config, new: &Config) -> Self {
+        let theme_changed = old.theme != new.theme;
+        let font_size_changed = old.font.size != new.font.size;
+        let font_family_changed = old.font.family != new.font.family;
+
+        // Fields whose consumers will pick up changes on the next paint.
+        // Grouped together so we can request a single redraw if any of them
+        // moved — we don't need a more granular signal than that.
+        let repaint_only = old.window.padding_x != new.window.padding_x
+            || old.window.padding_y != new.window.padding_y
+            || old.window.background_opacity != new.window.background_opacity
+            || old.cursor.style != new.cursor.style
+            || old.cursor.blink != new.cursor.blink
+            || old.mouse.hide_while_typing != new.mouse.hide_while_typing;
+
+        Self {
+            theme_changed,
+            font_size_changed,
+            font_family_changed,
+            repaint_only,
+        }
+    }
+
+    /// True when nothing the renderer / app cares about changed.
+    pub fn is_empty(&self) -> bool {
+        !(self.theme_changed
+            || self.font_size_changed
+            || self.font_family_changed
+            || self.repaint_only)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod tests {
+    use super::*;
+    use crate::CursorStyle;
+
+    #[test]
+    fn identical_configs_yield_empty_diff() {
+        let a = Config::default();
+        let b = Config::default();
+        assert!(ConfigDiff::between(&a, &b).is_empty());
+    }
+
+    #[test]
+    fn theme_change_is_detected() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.theme = Some("Gruvbox Dark".to_string());
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.theme_changed);
+        assert!(!d.font_size_changed);
+        assert!(!d.repaint_only);
+    }
+
+    #[test]
+    fn font_size_change_is_detected() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.font.size = 18.0;
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.font_size_changed);
+        assert!(!d.font_family_changed);
+        assert!(!d.theme_changed);
+    }
+
+    #[test]
+    fn font_family_change_is_separate_from_size() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.font.family = "Berkeley Mono".to_string();
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.font_family_changed);
+        assert!(!d.font_size_changed);
+    }
+
+    #[test]
+    fn cursor_style_change_is_repaint_only() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.cursor.style = CursorStyle::Bar;
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.repaint_only);
+        assert!(!d.theme_changed);
+        assert!(!d.font_size_changed);
+    }
+
+    #[test]
+    fn padding_change_is_repaint_only() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.window.padding_x = 12;
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.repaint_only);
+    }
+
+    #[test]
+    fn multiple_fields_set_multiple_flags() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.theme = Some("Gruvbox Dark".to_string());
+        b.font.size = 20.0;
+        b.window.padding_y = 8;
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.theme_changed);
+        assert!(d.font_size_changed);
+        assert!(d.repaint_only);
+        assert!(!d.is_empty());
+    }
+}

--- a/crates/seance-config/src/lib.rs
+++ b/crates/seance-config/src/lib.rs
@@ -7,9 +7,11 @@
 //! Theme files live alongside the config but use Ghostty's config syntax (not
 //! TOML) and are resolved by a separate module (issue #12).
 
+mod diff;
 mod schema;
 pub mod theme;
 
+pub use diff::ConfigDiff;
 pub use schema::{
     ClipboardConfig, Config, CursorConfig, CursorStyle, FontConfig, MouseConfig, ScrollbackConfig,
     WindowConfig,
@@ -20,6 +22,26 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 pub const CONFIG_FILENAME: &str = "config.toml";
+
+/// Errors surfaced by [`try_load`] / [`try_load_from`]. Used by the hot-reload
+/// path (#13) so a bad edit can be rejected instead of silently replaced with
+/// defaults.
+#[derive(Debug)]
+pub enum ConfigError {
+    Io(PathBuf, std::io::Error),
+    Parse(PathBuf, toml::de::Error),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::Io(p, e) => write!(f, "reading {}: {e}", p.display()),
+            ConfigError::Parse(p, e) => write!(f, "parsing {}: {e}", p.display()),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
 
 /// Return `$XDG_CONFIG_HOME/seance/` (or `$HOME/.config/seance/`), without
 /// creating it. Returns `None` if neither env var is set.
@@ -70,6 +92,21 @@ pub fn load_from(path: &Path) -> Config {
             Config::default()
         }
     }
+}
+
+/// Lower-level load that surfaces errors instead of falling back to defaults.
+/// Used by the hot-reload watcher — a mid-edit save with broken TOML should
+/// leave the running config untouched, not reset everything to defaults.
+///
+/// A missing file is treated as `Ok(Config::default())` (rather than an
+/// error) so a user who deletes their config can return to defaults live.
+pub fn try_load_from(path: &Path) -> Result<Config, ConfigError> {
+    let text = match fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Config::default()),
+        Err(err) => return Err(ConfigError::Io(path.to_path_buf(), err)),
+    };
+    toml::from_str(&text).map_err(|err| ConfigError::Parse(path.to_path_buf(), err))
 }
 
 #[cfg(test)]
@@ -138,6 +175,36 @@ mod tests {
         assert!(cfg.clipboard.write);
         assert!(cfg.clipboard.paste_protection);
         assert!(!cfg.clipboard.copy_on_select);
+    }
+
+    #[test]
+    fn try_load_rejects_bad_toml() {
+        let dir = env::temp_dir().join("seance-test-try-load-bad");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        fs::write(&path, "not = [a valid toml").unwrap();
+        let err = try_load_from(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse(..)), "{err}");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn try_load_accepts_good_toml() {
+        let dir = env::temp_dir().join("seance-test-try-load-good");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        fs::write(&path, "theme = \"Gruvbox Dark\"\n").unwrap();
+        let cfg = try_load_from(&path).unwrap();
+        assert_eq!(cfg.theme.as_deref(), Some("Gruvbox Dark"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn try_load_missing_file_yields_defaults() {
+        let path = env::temp_dir().join("seance-definitely-missing.toml");
+        let _ = fs::remove_file(&path);
+        let cfg = try_load_from(&path).unwrap();
+        assert!(cfg.theme.is_none());
     }
 
     #[test]

--- a/crates/seance-config/src/theme/mod.rs
+++ b/crates/seance-config/src/theme/mod.rs
@@ -15,7 +15,7 @@ pub mod parser;
 pub mod resolve;
 
 pub use parser::{ParseError, parse_source};
-pub use resolve::{LoadError, ThemeSpec, load};
+pub use resolve::{LoadError, ThemeSpec, load, try_load};
 
 /// One theme — a palette plus window/cursor/selection colors.
 ///

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -131,4 +131,11 @@ impl TerminalRenderer {
         let m = self.backend.metrics();
         self.cell_size = [m.cell_width, m.cell_height];
     }
+
+    /// Swap the theme. The theme is consumed CPU-side during the next
+    /// `update_frame()` / `render()`, so no cache or GPU buffer needs to be
+    /// touched — the caller just needs to trigger a repaint.
+    pub fn set_theme(&mut self, theme: Theme) {
+        self.theme = theme;
+    }
 }


### PR DESCRIPTION
Watch $XDG_CONFIG_HOME/seance/ for edits to config.toml and any file
under themes/. On change, debounce 100ms, reparse, diff against the
live config, and invalidate only what moved:

- theme change / active theme file edited → re-resolve via #12's
  pipeline and swap the palette
- font.size change → set_font_size (clears glyph atlas, recomputes
  cell metrics) + reflow
- cursor / padding / mouse.hide_while_typing change → mark_dirty;
  downstream consumers (#16, future) will pick up Config on repaint
- font.family change → log a notice (live family swap not supported)

Bad TOML or bad Ghostty-syntax theme is logged and the running config
/ theme is left untouched, so a mid-edit save never breaks a live
terminal.

Implementation notes:
- seance-config gains try_load_from (surfaces errors instead of
  logging + defaults) and ConfigDiff (pure, 7 unit tests).
- seance-render gains TerminalRenderer::set_theme — the theme is
  CPU-side, so the next update_frame picks it up; no cache work.
- seance-app wires a UserEvent enum through EventLoopProxy to keep
  reloads single-threaded with rendering (no torn reads). notify-
  debouncer-full owns its own worker thread, dropped on app exit.

Downstream keybind reload (issue #18) is intentionally a no-op here;
there is no keybind config surface yet.