### PR TITLE
feat(bench): add frame-time harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,6 +2065,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "seance-bench"
+version = "0.1.0"
+dependencies = [
+ "pollster",
+ "wgpu",
+]
+
+[[package]]
 name = "seance-config"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/seance-render",
     "crates/seance-config",
     "crates/seance-app",
+    "crates/seance-bench",
 ]
 
 [workspace.package]

--- a/crates/seance-bench/Cargo.toml
+++ b/crates/seance-bench/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "seance-bench"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "Frame-time bench harness for M2 perf work (CPU + headless GPU submit)"
+publish = false
+
+[[bin]]
+name = "frame-time"
+path = "src/bin/frame_time.rs"
+
+[dependencies]
+pollster = "0.4"
+wgpu = "29"
+
+[lints]
+workspace = true

--- a/crates/seance-bench/src/bin/frame_time.rs
+++ b/crates/seance-bench/src/bin/frame_time.rs
@@ -1,0 +1,95 @@
+//! Frame-time harness runner.
+//!
+//! Iterates each built-in workload, records p50/p95/p99 for CPU and
+//! headless-GPU submit, prints a fixed-width table to stdout.
+
+use std::time::Duration;
+
+use seance_bench::gpu::HeadlessGpu;
+use seance_bench::workloads::Workload;
+use seance_bench::{Stopwatch, Summary};
+
+const DEFAULT_ITERATIONS: usize = 10_000;
+
+fn main() {
+    let iterations = std::env::var("SEANCE_BENCH_ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_ITERATIONS);
+
+    let gpu = pollster::block_on(HeadlessGpu::new());
+    match &gpu {
+        Some(g) => println!("headless gpu: {}", g.adapter_name),
+        None => println!("headless gpu: unavailable (skipping GPU timings)"),
+    }
+    println!("iterations per workload: {iterations}\n");
+
+    print_header();
+    for workload in Workload::all() {
+        let cpu = run_cpu(&workload, iterations);
+        let gpu_summary = gpu.as_ref().map(|g| run_gpu(g, iterations));
+        print_row(workload.name, "cpu", &cpu);
+        if let Some(s) = gpu_summary {
+            print_row(workload.name, "gpu-submit", &s);
+        }
+    }
+}
+
+/// CPU proxy: sum the workload bytes (stand-in for future VT-feed +
+/// `CellBuilder::build_frame`). Cost scales with byte count so it's
+/// a meaningful relative baseline between workloads even as a stub.
+fn run_cpu(workload: &Workload, iterations: usize) -> Summary {
+    let mut sw = Stopwatch::with_capacity(iterations);
+    for _ in 0..iterations {
+        sw.time(|| {
+            let mut acc: u64 = 0;
+            for b in &workload.bytes {
+                acc = acc.wrapping_add(*b as u64);
+            }
+            std::hint::black_box(acc);
+        });
+    }
+    sw.summary()
+}
+
+fn run_gpu(gpu: &HeadlessGpu, iterations: usize) -> Summary {
+    let mut sw = Stopwatch::with_capacity(iterations);
+    for _ in 0..iterations {
+        sw.time(|| {
+            std::hint::black_box(gpu.submit_noop());
+        });
+    }
+    sw.summary()
+}
+
+fn print_header() {
+    println!(
+        "{:<16} {:<12} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "workload", "phase", "p50", "p95", "p99", "min", "max"
+    );
+    println!("{}", "-".repeat(84));
+}
+
+fn print_row(workload: &str, phase: &str, s: &Summary) {
+    println!(
+        "{:<16} {:<12} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        workload,
+        phase,
+        fmt(s.p50),
+        fmt(s.p95),
+        fmt(s.p99),
+        fmt(s.min),
+        fmt(s.max),
+    );
+}
+
+fn fmt(d: Duration) -> String {
+    let ns = d.as_nanos();
+    if ns < 10_000 {
+        format!("{}ns", ns)
+    } else if ns < 10_000_000 {
+        format!("{:.1}µs", ns as f64 / 1_000.0)
+    } else {
+        format!("{:.1}ms", ns as f64 / 1_000_000.0)
+    }
+}

--- a/crates/seance-bench/src/gpu.rs
+++ b/crates/seance-bench/src/gpu.rs
@@ -1,0 +1,68 @@
+//! Headless wgpu instance for GPU-side submit timing.
+//!
+//! No surface, no swapchain — the bench harness is never on-screen.
+//! Pipelines added later (once the renderer can run without a surface)
+//! will share this device.
+
+use std::time::{Duration, Instant};
+
+use wgpu::{
+    Backends, CommandEncoderDescriptor, Device, DeviceDescriptor, Instance, InstanceDescriptor,
+    MemoryHints, PollType, PowerPreference, Queue, RequestAdapterOptions,
+};
+
+pub struct HeadlessGpu {
+    pub adapter_name: String,
+    device: Device,
+    queue: Queue,
+}
+
+impl HeadlessGpu {
+    pub async fn new() -> Option<Self> {
+        let instance = Instance::new(InstanceDescriptor {
+            backends: Backends::PRIMARY,
+            ..InstanceDescriptor::new_without_display_handle()
+        });
+        let adapter = instance
+            .request_adapter(&RequestAdapterOptions {
+                power_preference: PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok()?;
+        let info = adapter.get_info();
+        let (device, queue) = adapter
+            .request_device(&DeviceDescriptor {
+                label: Some("seance-bench"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: MemoryHints::Performance,
+                ..Default::default()
+            })
+            .await
+            .ok()?;
+        Some(Self {
+            adapter_name: format!("{} ({:?})", info.name, info.backend),
+            device,
+            queue,
+        })
+    }
+
+    /// Submit an empty command buffer and wait for the queue to drain.
+    ///
+    /// Proxies "time to round-trip the GPU from the submit thread" — useful
+    /// as a baseline for M2 work that will layer cell uploads on top.
+    pub fn submit_noop(&self) -> Duration {
+        let encoder = self
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor { label: None });
+        let t0 = Instant::now();
+        self.queue.submit(Some(encoder.finish()));
+        let _ = self.device.poll(PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
+        t0.elapsed()
+    }
+}

--- a/crates/seance-bench/src/lib.rs
+++ b/crates/seance-bench/src/lib.rs
@@ -1,0 +1,130 @@
+//! Frame-time bench harness scaffold (parent: M2 epic #5, sub-issue #26).
+//!
+//! Two measurement surfaces today:
+//!   1. CPU per-iteration timing via [`Stopwatch`] — hooks a closure, produces
+//!      p50/p95/p99 over N samples.
+//!   2. Headless GPU adapter/device via [`gpu::HeadlessGpu`] — a wgpu
+//!      `Instance` with `Backends::PRIMARY`, no surface; `submit_noop` times
+//!      an empty command buffer submit + `Maintain::Wait`.
+//!
+//! The stream of VT bytes a workload feeds is owned by [`workloads::Workload`].
+//! Today workloads are byte-level stubs; once `seance-vt` exposes a PTY-less
+//! headless terminal (M2 #20 rides on the same need) the harness will feed
+//! those bytes through a real VT and time `CellBuilder::build_frame` end-to-end.
+
+pub mod gpu;
+pub mod workloads;
+
+use std::time::Duration;
+
+/// Collects per-iteration durations and reports percentile summaries.
+///
+/// `Duration` is kept as raw nanoseconds internally for sort + percentile
+/// math; we don't need higher precision than the OS clock.
+pub struct Stopwatch {
+    samples: Vec<u64>,
+}
+
+impl Stopwatch {
+    pub fn with_capacity(n: usize) -> Self {
+        Self {
+            samples: Vec::with_capacity(n),
+        }
+    }
+
+    /// Run `f` once, recording its elapsed time.
+    pub fn time<F: FnOnce()>(&mut self, f: F) {
+        let t0 = std::time::Instant::now();
+        f();
+        self.samples.push(t0.elapsed().as_nanos() as u64);
+    }
+
+    pub fn summary(&self) -> Summary {
+        Summary::from_samples(&self.samples)
+    }
+
+    pub fn sample_count(&self) -> usize {
+        self.samples.len()
+    }
+}
+
+/// Sorted percentile summary over a sample set.
+#[derive(Debug, Clone, Copy)]
+pub struct Summary {
+    pub count: usize,
+    pub min: Duration,
+    pub p50: Duration,
+    pub p95: Duration,
+    pub p99: Duration,
+    pub max: Duration,
+    pub mean: Duration,
+}
+
+impl Summary {
+    pub fn from_samples(samples: &[u64]) -> Self {
+        if samples.is_empty() {
+            let z = Duration::ZERO;
+            return Self {
+                count: 0,
+                min: z,
+                p50: z,
+                p95: z,
+                p99: z,
+                max: z,
+                mean: z,
+            };
+        }
+        let mut sorted = samples.to_vec();
+        sorted.sort_unstable();
+        let pct = |p: f64| {
+            let idx = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+            Duration::from_nanos(sorted[idx])
+        };
+        let sum: u128 = sorted.iter().map(|n| *n as u128).sum();
+        Self {
+            count: sorted.len(),
+            min: Duration::from_nanos(sorted[0]),
+            p50: pct(0.50),
+            p95: pct(0.95),
+            p99: pct(0.99),
+            max: Duration::from_nanos(*sorted.last().unwrap()),
+            mean: Duration::from_nanos((sum / sorted.len() as u128) as u64),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentiles_on_linear_ramp() {
+        // 101 samples [0..=100] so `round((N-1) * p)` lands on exact integers.
+        let samples: Vec<u64> = (0..=100).collect();
+        let s = Summary::from_samples(&samples);
+        assert_eq!(s.count, 101);
+        assert_eq!(s.min, Duration::from_nanos(0));
+        assert_eq!(s.max, Duration::from_nanos(100));
+        assert_eq!(s.p50, Duration::from_nanos(50));
+        assert_eq!(s.p95, Duration::from_nanos(95));
+        assert_eq!(s.p99, Duration::from_nanos(99));
+    }
+
+    #[test]
+    fn empty_summary_is_zero() {
+        let s = Summary::from_samples(&[]);
+        assert_eq!(s.count, 0);
+        assert_eq!(s.mean, Duration::ZERO);
+    }
+
+    #[test]
+    fn stopwatch_records_samples() {
+        let mut sw = Stopwatch::with_capacity(4);
+        for _ in 0..4 {
+            sw.time(|| {
+                let _ = std::hint::black_box(1 + 1);
+            });
+        }
+        assert_eq!(sw.sample_count(), 4);
+    }
+}

--- a/crates/seance-bench/src/workloads.rs
+++ b/crates/seance-bench/src/workloads.rs
@@ -1,0 +1,116 @@
+//! Synthetic VT byte streams modelled on the sub-issue #26 workload list.
+//!
+//! Each workload is a prerecorded blob of bytes a future VT-driving step
+//! will feed into a headless `libghostty-vt::Terminal`. Today the harness
+//! only measures byte-processing proxies — the workload shapes are chosen
+//! so the byte count + dirty-row density is representative.
+
+pub struct Workload {
+    pub name: &'static str,
+    pub bytes: Vec<u8>,
+    /// Hint: expected dirty rows per frame if each `bytes` slice were
+    /// fed frame-by-frame. Only used for diagnostic output for now.
+    pub dirty_rows_hint: u16,
+}
+
+impl Workload {
+    pub fn all() -> Vec<Self> {
+        vec![static_ls(), random_hexdump(), scroll_yes(), ansi_rainbow()]
+    }
+}
+
+/// Steady output — `ls -la`-style listing. No repaint pressure.
+fn static_ls() -> Workload {
+    let mut bytes = Vec::with_capacity(4096);
+    bytes.extend_from_slice(b"total 128\r\n");
+    for i in 0..40 {
+        let line = format!(
+            "-rw-r--r-- 1 user staff {:>6} Apr 19 12:{:02} file_{:03}.txt\r\n",
+            1024 + i * 17,
+            i % 60,
+            i
+        );
+        bytes.extend_from_slice(line.as_bytes());
+    }
+    Workload {
+        name: "static-ls",
+        bytes,
+        dirty_rows_hint: 41,
+    }
+}
+
+/// High-churn output — `cat /dev/urandom | hexdump` proxy.
+/// Every cell on every line changes; worst case for any per-row cache.
+fn random_hexdump() -> Workload {
+    let mut bytes = Vec::with_capacity(8192);
+    let mut state: u32 = 0x9E3779B9;
+    for row in 0..50 {
+        let mut line = format!("{:08x}  ", row * 16);
+        for _ in 0..16 {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            line.push_str(&format!("{:02x} ", state as u8));
+        }
+        line.push_str("\r\n");
+        bytes.extend_from_slice(line.as_bytes());
+    }
+    Workload {
+        name: "random-hexdump",
+        bytes,
+        dirty_rows_hint: 50,
+    }
+}
+
+/// Rapid scroll — `yes | head` proxy. Same short line repeated with \n,
+/// forcing libghostty-vt's scroll path.
+fn scroll_yes() -> Workload {
+    let mut bytes = Vec::with_capacity(4096);
+    for _ in 0..1000 {
+        bytes.extend_from_slice(b"y\r\n");
+    }
+    Workload {
+        name: "scroll-yes",
+        bytes,
+        dirty_rows_hint: 1,
+    }
+}
+
+/// SGR color churn — stresses shape-cache keying on attribute changes.
+fn ansi_rainbow() -> Workload {
+    let mut bytes = Vec::with_capacity(4096);
+    for row in 0..30 {
+        for col in 0..80 {
+            let fg = 31 + ((row + col) % 7) as u8;
+            bytes.extend_from_slice(format!("\x1b[{}m#", fg).as_bytes());
+        }
+        bytes.extend_from_slice(b"\x1b[0m\r\n");
+    }
+    Workload {
+        name: "ansi-rainbow",
+        bytes,
+        dirty_rows_hint: 30,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_workload_has_bytes() {
+        for w in Workload::all() {
+            assert!(!w.bytes.is_empty(), "{} is empty", w.name);
+            assert!(w.dirty_rows_hint > 0);
+        }
+    }
+
+    #[test]
+    fn names_are_unique() {
+        let all = Workload::all();
+        let mut names: Vec<_> = all.iter().map(|w| w.name).collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), Workload::all().len());
+    }
+}


### PR DESCRIPTION
New non-publishing crate under M2. Ships three pieces today:

- Stopwatch + Summary (p50/p95/p99/min/max/mean) over u64 ns samples.
- HeadlessGpu: wgpu Instance (Backends::PRIMARY) + adapter + device with
  no surface; exposes submit_noop() timing a round-trip empty submit.
- Workloads: static-ls, random-hexdump, scroll-yes, ansi-rainbow — byte
  streams sized to the scenarios called out in the issue.

The frame-time binary iterates each workload N times (default 10k,
SEANCE_BENCH_ITERS overrides), prints a per-workload percentile table
for CPU and GPU submit. The CPU cost is a byte-checksum stub until
seance-vt exposes a PTY-less terminal (M2 #20 rides on the same need).

https://claude.ai/code/session_01KTKeSLgYTFpgz8YvqBZ3Qt