### PR TITLE
feat(macos): drag window with Super-click

### DIFF
--- a/crates/seance-app/src/main.rs
+++ b/crates/seance-app/src/main.rs
@@ -427,6 +427,13 @@ impl App {
     }
 
     fn handle_mouse_press(&mut self) {
+        if self.modifiers.state().super_key()
+            && let Some(window) = self.window.as_ref()
+        {
+            let _ = window.drag_window();
+            return;
+        }
+
         let Some(r) = self.renderer.as_ref() else {
             return;
         };

--- a/crates/seance-app/src/platform.rs
+++ b/crates/seance-app/src/platform.rs
@@ -31,7 +31,6 @@ pub fn configure_window(window: &winit::window::Window) {
         let _: () = msg_send![nswindow, setStyleMask: style_mask];
         let _: () = msg_send![nswindow, setTitlebarAppearsTransparent: true];
         let _: () = msg_send![nswindow, setTitleVisibility: TITLE_HIDDEN];
-        let _: () = msg_send![nswindow, setMovableByWindowBackground: true];
 
         // Hide close, minimize, zoom buttons.
         for i in 0_isize..3 {


### PR DESCRIPTION
Closes #138

## Summary
Replace the native macOS window dragging behavior with a custom implementation that allows users to drag the window by holding the Super key and clicking anywhere on the window.

## Key Changes
- Added Super key + mouse press detection in `handle_mouse_press()` to initiate window dragging via `window.drag_window()`
- Removed the `setMovableByWindowBackground: true` call from macOS window configuration, which previously allowed dragging from any background area
- The custom implementation provides more explicit control over window dragging behavior

## Implementation Details
- When the Super key modifier is active during a mouse press, the window drag operation is initiated and the function returns early, preventing further mouse event processing
- This replaces the implicit background dragging behavior with an explicit modifier-based approach, giving users clearer visual feedback about when dragging is possible

https://claude.ai/code/session_016uW8BVsjtrDo8bN3Et92Uw