### PR TITLE
feat(window): add configurable padding

### DIFF
--- a/crates/seance-app/src/main.rs
+++ b/crates/seance-app/src/main.rs
@@ -236,8 +236,21 @@ impl App {
         if diff.theme_changed {
             self.reload_theme();
         }
+        if diff.window_padding_changed {
+            self.apply_window_padding();
+        }
         if diff.repaint_only {
             self.mark_dirty();
+        }
+    }
+
+    /// Push the configured window padding to the renderer and reflow the PTY.
+    /// `grid_size()` shrinks when padding grows, so a reflow is required to
+    /// keep the shell's SIGWINCH in sync.
+    fn apply_window_padding(&mut self) {
+        if let (Some(r), Some(w)) = (&mut self.renderer, &self.window) {
+            r.set_window_padding([self.config.window.padding_x, self.config.window.padding_y]);
+            self.reflow(w.inner_size());
         }
     }
 
@@ -469,6 +482,7 @@ impl ApplicationHandler<UserEvent> for App {
             scale: window.scale_factor(),
             font_family: self.config.font.family.clone(),
             font_size: self.font_size,
+            window_padding: [self.config.window.padding_x, self.config.window.padding_y],
             theme,
         };
 

--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -26,7 +26,10 @@ pub struct ConfigDiff {
     /// `font.family` changed — live reload not yet implemented; caller logs
     /// a notice.
     pub font_family_changed: bool,
-    /// Cursor/padding/opacity/mouse-hide changed — a plain repaint is enough
+    /// `window.padding_x|y` changed — caller must push the new padding to
+    /// the renderer and reflow the PTY (cols/rows shrink when padding grows).
+    pub window_padding_changed: bool,
+    /// Cursor/opacity/mouse-hide changed — a plain repaint is enough
     /// (downstream consumers read `Config` directly on the next frame).
     pub repaint_only: bool,
 }
@@ -38,12 +41,13 @@ impl ConfigDiff {
         let font_size_changed = old.font.size != new.font.size;
         let font_family_changed = old.font.family != new.font.family;
 
+        let window_padding_changed = old.window.padding_x != new.window.padding_x
+            || old.window.padding_y != new.window.padding_y;
+
         // Fields whose consumers will pick up changes on the next paint.
         // Grouped together so we can request a single redraw if any of them
         // moved — we don't need a more granular signal than that.
-        let repaint_only = old.window.padding_x != new.window.padding_x
-            || old.window.padding_y != new.window.padding_y
-            || old.window.background_opacity != new.window.background_opacity
+        let repaint_only = old.window.background_opacity != new.window.background_opacity
             || old.cursor.style != new.cursor.style
             || old.cursor.blink != new.cursor.blink
             || old.mouse.hide_while_typing != new.mouse.hide_while_typing;
@@ -52,6 +56,7 @@ impl ConfigDiff {
             theme_changed,
             font_size_changed,
             font_family_changed,
+            window_padding_changed,
             repaint_only,
         }
     }
@@ -61,6 +66,7 @@ impl ConfigDiff {
         !(self.theme_changed
             || self.font_size_changed
             || self.font_family_changed
+            || self.window_padding_changed
             || self.repaint_only)
     }
 }
@@ -122,12 +128,13 @@ mod tests {
     }
 
     #[test]
-    fn padding_change_is_repaint_only() {
+    fn padding_change_sets_window_padding_flag() {
         let a = Config::default();
         let mut b = Config::default();
         b.window.padding_x = 12;
         let d = ConfigDiff::between(&a, &b);
-        assert!(d.repaint_only);
+        assert!(d.window_padding_changed);
+        assert!(!d.repaint_only);
     }
 
     #[test]
@@ -140,7 +147,7 @@ mod tests {
         let d = ConfigDiff::between(&a, &b);
         assert!(d.theme_changed);
         assert!(d.font_size_changed);
-        assert!(d.repaint_only);
+        assert!(d.window_padding_changed);
         assert!(!d.is_empty());
     }
 }

--- a/crates/seance-config/src/lib.rs
+++ b/crates/seance-config/src/lib.rs
@@ -119,7 +119,7 @@ mod tests {
         let def = Config::default();
         assert_eq!(cfg.font.family, def.font.family);
         assert_eq!(cfg.font.size, def.font.size);
-        assert_eq!(cfg.window.padding_x, 0);
+        assert_eq!(cfg.window.padding_x, 16);
         assert_eq!(cfg.cursor.style, CursorStyle::Block);
         assert!(cfg.theme.is_none());
     }

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -58,8 +58,8 @@ pub struct WindowConfig {
 impl Default for WindowConfig {
     fn default() -> Self {
         Self {
-            padding_x: 0,
-            padding_y: 0,
+            padding_x: 16,
+            padding_y: 16,
             decoration: true,
             background_opacity: 1.0,
         }

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -16,6 +16,10 @@ pub struct RendererConfig {
     pub scale: f64,
     pub font_family: String,
     pub font_size: f32,
+    /// Inner gutter between window edges and the cell grid, in physical
+    /// pixels. `[x, y]`. The area outside the grid is filled by the
+    /// fullscreen bg pass with `theme.bg`.
+    pub window_padding: [u16; 2],
     pub theme: Theme,
 }
 
@@ -45,6 +49,7 @@ pub struct TerminalRenderer {
     cell_size: [f32; 2],
     surface_width: u32,
     surface_height: u32,
+    window_padding: [u16; 2],
 }
 
 impl TerminalRenderer {
@@ -66,6 +71,7 @@ impl TerminalRenderer {
             cell_size,
             surface_width: config.width,
             surface_height: config.height,
+            window_padding: config.window_padding,
         })
     }
 
@@ -75,8 +81,12 @@ impl TerminalRenderer {
 
     pub fn grid_size(&self) -> (u16, u16) {
         let [cw, ch] = self.cell_size;
-        let cols = (self.surface_width as f32 / cw) as u16;
-        let rows = (self.surface_height as f32 / ch) as u16;
+        let usable_w =
+            (self.surface_width as f32 - 2.0 * f32::from(self.window_padding[0])).max(cw);
+        let usable_h =
+            (self.surface_height as f32 - 2.0 * f32::from(self.window_padding[1])).max(ch);
+        let cols = (usable_w / cw) as u16;
+        let rows = (usable_h / ch) as u16;
         (cols.max(1), rows.max(1))
     }
 
@@ -103,6 +113,7 @@ impl TerminalRenderer {
             self.backend.as_mut(),
             self.surface_width,
             self.surface_height,
+            self.window_padding,
             &self.theme,
         );
         if let Some(fi) = self.cell_builder.last_frame() {
@@ -137,5 +148,12 @@ impl TerminalRenderer {
     /// touched — the caller just needs to trigger a repaint.
     pub fn set_theme(&mut self, theme: Theme) {
         self.theme = theme;
+    }
+
+    /// Update the configured window padding. `grid_size()` shrinks
+    /// accordingly, so callers should call `reflow()` afterwards to push the
+    /// new cols/rows to the PTY.
+    pub fn set_window_padding(&mut self, padding: [u16; 2]) {
+        self.window_padding = padding;
     }
 }

--- a/crates/seance-render/src/text/cell_builder.rs
+++ b/crates/seance-render/src/text/cell_builder.rs
@@ -104,6 +104,7 @@ impl CellBuilder {
         backend: &mut dyn TextBackend,
         surface_width: u32,
         surface_height: u32,
+        window_padding: [u16; 2],
         theme: &Theme,
     ) {
         let (baseline, geom) = {
@@ -114,6 +115,7 @@ impl CellBuilder {
                 m.cell_height,
                 surface_width,
                 surface_height,
+                window_padding,
             );
             (m.baseline, g)
         };
@@ -177,10 +179,21 @@ fn geometry(
     cell_height: f32,
     surface_width: u32,
     surface_height: u32,
+    window_padding: [u16; 2],
 ) -> FrameGeometry {
     let (cols, rows) = source.grid_size();
-    let pad_x = ((surface_width as f32 - cols as f32 * cell_width) / 2.0).max(0.0);
-    let pad_y = ((surface_height as f32 - rows as f32 * cell_height) / 2.0).max(0.0);
+    // User-configured padding anchors the grid at `(padding_x, padding_y)`.
+    // Any residual between the grid pixel extent and the surface is left on
+    // the right/bottom and filled by the fullscreen bg pass — matches
+    // Ghostty/Alacritty semantics (padding = minimum gutter, not centering).
+    let user_pad_x = f32::from(window_padding[0]);
+    let user_pad_y = f32::from(window_padding[1]);
+    let pad_x = user_pad_x
+        .min((surface_width as f32 - cols as f32 * cell_width).max(0.0))
+        .max(0.0);
+    let pad_y = user_pad_y
+        .min((surface_height as f32 - rows as f32 * cell_height).max(0.0))
+        .max(0.0);
     FrameGeometry {
         cell_width,
         cell_height,
@@ -367,5 +380,34 @@ mod tests {
         assert_eq!(requests[1].text, "B");
         assert_eq!(requests[1].col, 2);
         assert_eq!(requests[1].fg, [10, 20, 30, 255]);
+    }
+
+    #[test]
+    fn geometry_honors_user_padding() {
+        let cells: [(&str, CellColor, CellColor); 0] = [];
+        let mut source = FakeFrame {
+            cols: 10,
+            rows: 5,
+            cells: &cells,
+        };
+        // 10×5 grid of 10×20 cells = 100×100 grid pixels inside a 200×200
+        // surface. With padding [12, 6] the grid anchors at (12, 6).
+        let g = geometry(&mut source, 10.0, 20.0, 200, 200, [12, 6]);
+        assert_eq!(g.grid_padding, [12.0, 6.0, 12.0, 6.0]);
+    }
+
+    #[test]
+    fn geometry_clamps_padding_to_surface() {
+        let cells: [(&str, CellColor, CellColor); 0] = [];
+        let mut source = FakeFrame {
+            cols: 10,
+            rows: 5,
+            cells: &cells,
+        };
+        // Requested padding exceeds the residual space (surface - grid);
+        // clamp to the residual so the grid still fits entirely on-screen.
+        let g = geometry(&mut source, 10.0, 20.0, 110, 110, [50, 40]);
+        assert_eq!(g.grid_padding[0], 10.0);
+        assert_eq!(g.grid_padding[1], 10.0);
     }
 }


### PR DESCRIPTION
Closes #15

## Summary
This PR adds support for configurable window padding that creates a gutter between the window edges and the terminal cell grid. The padding is user-configurable and anchors the grid at the specified offset, with any residual space filled by the background color (matching Ghostty/Alacritty semantics).

## Key Changes

- **Renderer Configuration**: Added `window_padding: [u16; 2]` field to `RendererConfig` to specify x/y padding in physical pixels
- **Grid Geometry**: Updated `geometry()` function to respect user-configured padding while clamping it to available surface space, ensuring the grid always fits on-screen
- **Grid Size Calculation**: Modified `TerminalRenderer::grid_size()` to account for padding when calculating available columns and rows, causing the grid to shrink when padding increases
- **Configuration Diffing**: Added `window_padding_changed` flag to `ConfigDiff` to distinguish padding changes from simple repaints, since padding changes require PTY reflow
- **Application Integration**: 
  - Added `apply_window_padding()` method to push padding changes to the renderer and trigger PTY reflow
  - Integrated padding change handling into the config reload flow
  - Pass padding to renderer during initialization

## Implementation Details

- Padding is treated as a minimum gutter: the grid anchors at `(padding_x, padding_y)` with residual space left on the right/bottom edges
- User-configured padding is clamped to the available surface space to prevent the grid from being pushed off-screen
- When padding changes, `grid_size()` shrinks accordingly, requiring a PTY reflow to keep the shell's SIGWINCH in sync
- Added comprehensive tests verifying padding is honored and properly clamped to surface bounds
- Defaults `window.padding_x`/`padding_y` bumped from `0` → `16` (Ghostty-like breathing room)

https://claude.ai/code/session_01PuAwHNmMAg6nYkJRt6P4RL