### PR TITLE
feat(macos): hide titlebar chrome

### DIFF
--- a/crates/seance-app/src/platform.rs
+++ b/crates/seance-app/src/platform.rs
@@ -14,6 +14,11 @@ pub fn configure_window(window: &winit::window::Window) {
     // NSWindowTitleVisibility::Hidden.
     const TITLE_HIDDEN: isize = 1;
 
+    // NSTitlebarSeparatorStyle::None — suppresses the 1 px hairline AppKit
+    // otherwise draws at the titlebar/content boundary when the content view
+    // uses FULLSIZE_CONTENT_VIEW.
+    const TITLEBAR_SEPARATOR_NONE: isize = 1;
+
     let Ok(handle) = window.window_handle() else {
         return;
     };
@@ -31,6 +36,10 @@ pub fn configure_window(window: &winit::window::Window) {
         let _: () = msg_send![nswindow, setStyleMask: style_mask];
         let _: () = msg_send![nswindow, setTitlebarAppearsTransparent: true];
         let _: () = msg_send![nswindow, setTitleVisibility: TITLE_HIDDEN];
+        let _: () = msg_send![
+            nswindow,
+            setTitlebarSeparatorStyle: TITLEBAR_SEPARATOR_NONE
+        ];
 
         // Hide close, minimize, zoom buttons.
         for i in 0_isize..3 {

--- a/crates/seance-app/src/platform.rs
+++ b/crates/seance-app/src/platform.rs
@@ -49,6 +49,32 @@ pub fn configure_window(window: &winit::window::Window) {
             }
         }
 
+        // Hide the `NSTitlebarContainerView` inside the window's theme frame.
+        // `titlebarAppearsTransparent` + `fullSizeContentView` leave this view
+        // in the hierarchy, and it paints a 1 px highlight at the top of the
+        // window regardless of `titlebarSeparatorStyle`. Mirrors Ghostty's
+        // `HiddenTitlebarTerminalWindow.reapplyHiddenStyle`.
+        if let Some(titlebar_cls) = AnyClass::get(c"NSTitlebarContainerView") {
+            let content_view: *mut AnyObject = msg_send![nswindow, contentView];
+            if !content_view.is_null() {
+                let theme_frame: *mut AnyObject = msg_send![content_view, superview];
+                if !theme_frame.is_null() {
+                    let subviews: *mut AnyObject = msg_send![theme_frame, subviews];
+                    if !subviews.is_null() {
+                        let count: usize = msg_send![subviews, count];
+                        for i in 0..count {
+                            let sub: *mut AnyObject = msg_send![subviews, objectAtIndex: i];
+                            let is_titlebar: bool = msg_send![sub, isKindOfClass: titlebar_cls];
+                            if is_titlebar {
+                                let _: () = msg_send![sub, setHidden: true];
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         if let Some(app_class) = AnyClass::get(c"NSApplication") {
             let app: *mut AnyObject = msg_send![app_class, sharedApplication];
             if !app.is_null() {


### PR DESCRIPTION
Closes #139

## Summary
Improves the appearance of the window on macOS by suppressing the hairline separator that appears at the titlebar/content boundary and hiding the titlebar container view that remains in the view hierarchy when using transparent titlebar with full-size content view.

## Changes
- Add `setTitlebarSeparatorStyle` call with `NSTitlebarSeparatorStyle::None` to suppress the 1px hairline AppKit draws at the titlebar/content boundary
- Hide the `NSTitlebarContainerView` by traversing the window's view hierarchy and setting its hidden property, which prevents a 1px highlight from appearing at the top of the window
- This approach mirrors the implementation used in Ghostty's `HiddenTitlebarTerminalWindow.reapplyHiddenStyle`

## Implementation Details
The titlebar container view hiding logic:
- Safely traverses from the content view → superview (theme frame) → subviews
- Iterates through subviews to find the `NSTitlebarContainerView` instance
- Sets the view's hidden property when found
- Includes null checks at each step to handle edge cases safely

https://claude.ai/code/session_01DNgqNEo225R2skgYoudkn3