### PR TITLE
docs: add issue and commit guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,28 +51,27 @@ commit message, not the code — it rots as the codebase evolves.
 
 ## Working on issues
 
-Epics are tracked on GitHub under the `epic` label (M1–M9). Every non-epic
-issue must be attached to its parent epic as a sub-issue — when filing a new
-issue, identify the epic it belongs under and link it. If no existing epic
-fits, open a new epic first rather than creating an orphan issue.
+Epics are tracked on GitHub under the `epic` label (M1–M9). Every non-epic issue
+must be attached to its parent epic as a sub-issue — when filing a new issue,
+identify the epic it belongs under and link it. If no existing epic fits, open a
+new epic first rather than creating an orphan issue.
 
 When picking up a sub-issue:
 
-1. Read the parent epic for context, plus `docs/architecture.md` for the
-   section it touches.
+1. Read the parent epic for context, plus `docs/architecture.md` for the section
+   it touches.
 2. Reference the specific files/modules you intend to change in the PR
    description.
 3. Keep changes scoped to the sub-issue — do not batch unrelated cleanups.
-4. Run `cargo fmt`, `cargo clippy`, and the relevant tests before opening a
-   PR.
+4. Run `cargo fmt`, `cargo clippy`, and the relevant tests before opening a PR.
 
 ## Commit messages
 
 Use Conventional Commits (<https://www.conventionalcommits.org/>) for every
 commit and PR title: `type(scope): summary`, with `type` drawn from `feat`,
 `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`. Keep the
-subject line under 72 characters. Put the why (and any design narration
-that would otherwise leak into code comments) in the body.
+subject line under 72 characters. Put the why (and any design narration that
+would otherwise leak into code comments) in the body.
 
 ## Branches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,16 +51,28 @@ commit message, not the code — it rots as the codebase evolves.
 
 ## Working on issues
 
-Epics are tracked on GitHub under the `epic` label (M1–M7). Each epic decomposes
-into sub-issues sized for roughly one agent session. When picking up a
-sub-issue:
+Epics are tracked on GitHub under the `epic` label (M1–M9). Every non-epic
+issue must be attached to its parent epic as a sub-issue — when filing a new
+issue, identify the epic it belongs under and link it. If no existing epic
+fits, open a new epic first rather than creating an orphan issue.
 
-1. Read the parent epic for context, plus `docs/architecture.md` for the section
-   it touches.
+When picking up a sub-issue:
+
+1. Read the parent epic for context, plus `docs/architecture.md` for the
+   section it touches.
 2. Reference the specific files/modules you intend to change in the PR
    description.
 3. Keep changes scoped to the sub-issue — do not batch unrelated cleanups.
-4. Run `cargo fmt`, `cargo clippy`, and the relevant tests before opening a PR.
+4. Run `cargo fmt`, `cargo clippy`, and the relevant tests before opening a
+   PR.
+
+## Commit messages
+
+Use Conventional Commits (<https://www.conventionalcommits.org/>) for every
+commit and PR title: `type(scope): summary`, with `type` drawn from `feat`,
+`fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`. Keep the
+subject line under 72 characters. Put the why (and any design narration
+that would otherwise leak into code comments) in the body.
 
 ## Branches
 


### PR DESCRIPTION
## Summary
Updated CLAUDE.md to improve guidance on issue management and establish commit message conventions for the project.

## Key Changes
- **Epic tracking**: Updated epic count from M1–M7 to M1–M9 and added requirement that all non-epic issues must be linked to a parent epic. New guidance clarifies that orphan issues should be avoided and new epics should be created if no existing epic fits.
- **Issue workflow**: Reorganized and clarified the sub-issue pickup process with improved formatting for readability.
- **Commit conventions**: Added new section documenting Conventional Commits format (`type(scope): summary`) with specific type options (`feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`), 72-character subject line limit, and guidance on using commit bodies for design rationale.

## Implementation Details
These are documentation-only changes that establish clearer standards for contributors. The commit message guidelines follow the widely-adopted Conventional Commits specification to improve commit history clarity and enable better tooling integration.

https://claude.ai/code/session_01Sh8dotBo1XLpJNBiQDKhx1