### PR TITLE
feat(config): set sensible config defaults

### DIFF
--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -135,7 +135,7 @@ mod tests {
     fn font_adjust_cell_height_change_is_detected() {
         let a = Config::default();
         let mut b = Config::default();
-        b.font.adjust_cell_height = Some("20%".to_string());
+        b.font.adjust_cell_height = Some("10%".to_string());
         let d = ConfigDiff::between(&a, &b);
         assert!(d.font_adjust_cell_height_changed);
         assert!(!d.font_size_changed);
@@ -157,7 +157,7 @@ mod tests {
     fn min_contrast_change_is_repaint_only() {
         let a = Config::default();
         let mut b = Config::default();
-        b.font.min_contrast = 1.1;
+        b.font.min_contrast = 1.5;
         let d = ConfigDiff::between(&a, &b);
         assert!(d.repaint_only);
         assert!(!d.theme_changed);

--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -135,7 +135,7 @@ mod tests {
     fn font_adjust_cell_height_change_is_detected() {
         let a = Config::default();
         let mut b = Config::default();
-        b.font.adjust_cell_height = Some("10%".to_string());
+        b.font.adjust_cell_height = Some("20%".to_string());
         let d = ConfigDiff::between(&a, &b);
         assert!(d.font_adjust_cell_height_changed);
         assert!(!d.font_size_changed);

--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -135,7 +135,7 @@ mod tests {
     fn font_adjust_cell_height_change_is_detected() {
         let a = Config::default();
         let mut b = Config::default();
-        b.font.adjust_cell_height = Some("20%".to_string());
+        b.font.adjust_cell_height = Some("10%".to_string());
         let d = ConfigDiff::between(&a, &b);
         assert!(d.font_adjust_cell_height_changed);
         assert!(!d.font_size_changed);
@@ -146,7 +146,7 @@ mod tests {
     fn cursor_style_change_is_repaint_only() {
         let a = Config::default();
         let mut b = Config::default();
-        b.cursor.style = CursorStyle::Block;
+        b.cursor.style = CursorStyle::Bar;
         let d = ConfigDiff::between(&a, &b);
         assert!(d.repaint_only);
         assert!(!d.theme_changed);
@@ -168,7 +168,7 @@ mod tests {
     fn padding_change_sets_window_padding_flag() {
         let a = Config::default();
         let mut b = Config::default();
-        b.window.padding_x = 12;
+        b.window.padding_x = 20;
         let d = ConfigDiff::between(&a, &b);
         assert!(d.window_padding_changed);
         assert!(!d.repaint_only);

--- a/crates/seance-config/src/lib.rs
+++ b/crates/seance-config/src/lib.rs
@@ -119,8 +119,8 @@ mod tests {
         let def = Config::default();
         assert_eq!(cfg.font.family, def.font.family);
         assert_eq!(cfg.font.size, def.font.size);
-        assert_eq!(cfg.window.padding_x, 2);
-        assert_eq!(cfg.cursor.style, CursorStyle::Bar);
+        assert_eq!(cfg.window.padding_x, 12);
+        assert_eq!(cfg.cursor.style, CursorStyle::Block);
         assert_eq!(cfg.theme.as_deref(), Some("Catppuccin Frappe"));
     }
 

--- a/crates/seance-config/src/lib.rs
+++ b/crates/seance-config/src/lib.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(cfg.font.size, def.font.size);
         assert_eq!(cfg.window.padding_x, 16);
         assert_eq!(cfg.cursor.style, CursorStyle::Bar);
-        assert!(cfg.theme.is_none());
+        assert_eq!(cfg.theme.as_deref(), Some("Catppuccin Frappe"));
     }
 
     #[test]
@@ -138,8 +138,8 @@ mod tests {
         assert_eq!(cfg.theme.as_deref(), Some("Catppuccin Mocha"));
         assert_eq!(cfg.font.family, "Berkeley Mono");
         assert_eq!(cfg.font.size, 16.0);
-        assert_eq!(cfg.font.min_contrast, 1.0);
-        assert!(cfg.font.features.is_empty());
+        assert_eq!(cfg.font.min_contrast, 1.1);
+        assert_eq!(cfg.font.features, vec!["calt".to_string()]);
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod tests {
         let path = env::temp_dir().join("seance-definitely-missing.toml");
         let _ = fs::remove_file(&path);
         let cfg = try_load_from(&path).unwrap();
-        assert!(cfg.theme.is_none());
+        assert_eq!(cfg.theme.as_deref(), Some("Catppuccin Frappe"));
     }
 
     #[test]

--- a/crates/seance-config/src/lib.rs
+++ b/crates/seance-config/src/lib.rs
@@ -119,7 +119,7 @@ mod tests {
         let def = Config::default();
         assert_eq!(cfg.font.family, def.font.family);
         assert_eq!(cfg.font.size, def.font.size);
-        assert_eq!(cfg.window.padding_x, 16);
+        assert_eq!(cfg.window.padding_x, 2);
         assert_eq!(cfg.cursor.style, CursorStyle::Bar);
         assert_eq!(cfg.theme.as_deref(), Some("Catppuccin Frappe"));
     }

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -31,6 +31,7 @@ impl Default for Config {
             clipboard: ClipboardConfig::default(),
             scrollback: ScrollbackConfig::default(),
             mouse: MouseConfig::default(),
+            input: InputConfig::default(),
         }
     }
 }

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -54,7 +54,7 @@ impl Default for FontConfig {
             family: "JetBrainsMono Nerd Font".to_string(),
             size: 14.0,
             features: vec!["calt".to_string()],
-            adjust_cell_height: Some("15%".to_string()),
+            adjust_cell_height: Some("20%".to_string()),
             adjust_cell_width: None,
             min_contrast: 1.1,
             fallback: Vec::new(),
@@ -74,8 +74,8 @@ pub struct WindowConfig {
 impl Default for WindowConfig {
     fn default() -> Self {
         Self {
-            padding_x: 2,
-            padding_y: 2,
+            padding_x: 12,
+            padding_y: 0,
             decoration: true,
             background_opacity: 1.0,
         }
@@ -85,8 +85,8 @@ impl Default for WindowConfig {
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum CursorStyle {
-    Block,
     #[default]
+    Block,
     Bar,
     Underline,
 }
@@ -101,7 +101,7 @@ pub struct CursorConfig {
 impl Default for CursorConfig {
     fn default() -> Self {
         Self {
-            style: CursorStyle::Bar,
+            style: CursorStyle::Block,
             blink: false,
         }
     }

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -73,8 +73,8 @@ pub struct WindowConfig {
 impl Default for WindowConfig {
     fn default() -> Self {
         Self {
-            padding_x: 16,
-            padding_y: 16,
+            padding_x: 2,
+            padding_y: 2,
             decoration: true,
             background_opacity: 1.0,
         }

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -53,7 +53,7 @@ impl Default for FontConfig {
             family: "JetBrainsMono Nerd Font".to_string(),
             size: 14.0,
             features: vec!["calt".to_string()],
-            adjust_cell_height: Some("20%".to_string()),
+            adjust_cell_height: None,
             adjust_cell_width: None,
             min_contrast: 1.1,
             fallback: Vec::new(),

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -8,7 +8,7 @@
 
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub theme: Option<String>,
@@ -19,6 +19,20 @@ pub struct Config {
     pub scrollback: ScrollbackConfig,
     pub mouse: MouseConfig,
     pub input: InputConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            theme: Some("Catppuccin Frappe".to_string()),
+            font: FontConfig::default(),
+            window: WindowConfig::default(),
+            cursor: CursorConfig::default(),
+            clipboard: ClipboardConfig::default(),
+            scrollback: ScrollbackConfig::default(),
+            mouse: MouseConfig::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -38,10 +52,10 @@ impl Default for FontConfig {
         Self {
             family: "JetBrainsMono Nerd Font".to_string(),
             size: 14.0,
-            features: Vec::new(),
-            adjust_cell_height: None,
+            features: vec!["calt".to_string()],
+            adjust_cell_height: Some("20%".to_string()),
             adjust_cell_width: None,
-            min_contrast: 1.0,
+            min_contrast: 1.1,
             fallback: Vec::new(),
         }
     }
@@ -120,7 +134,7 @@ pub struct ScrollbackConfig {
 
 impl Default for ScrollbackConfig {
     fn default() -> Self {
-        Self { limit: 10_000 }
+        Self { limit: 50_000 }
     }
 }
 

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -53,7 +53,7 @@ impl Default for FontConfig {
             family: "JetBrainsMono Nerd Font".to_string(),
             size: 14.0,
             features: vec!["calt".to_string()],
-            adjust_cell_height: None,
+            adjust_cell_height: Some("15%".to_string()),
             adjust_cell_width: None,
             min_contrast: 1.1,
             fallback: Vec::new(),


### PR DESCRIPTION
Supersedes #185, which GitHub auto-closed when main was history-rewritten to drop a deleted email and switch every commit to a GPG signature verified under the noreply identity.

Supersedes #181, which GitHub auto-closed after `main` was history-rewritten.

## Summary

- align `Config` defaults with the intended out-of-the-box setup
- adjust font and scrollback defaults
- update tests for the new defaults
