### PR TITLE
Add dirty row tracking to enable incremental frame rendering

### DIFF
--- a/crates/seance-vt/src/frame.rs
+++ b/crates/seance-vt/src/frame.rs
@@ -112,6 +112,25 @@ pub struct CursorInfo {
     pub shape: Option<CursorShape>,
 }
 
+/// Summary of what rows have changed since the last
+/// [`FrameSource::clear_dirty`].
+///
+/// Consumers use this to skip rebuild work (shape cache, bg cells, atlas
+/// uploads) for rows whose prior state is still valid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirtySnapshot {
+    /// Nothing changed — the renderer may reuse the previous frame's
+    /// buffers verbatim.
+    Clean,
+    /// Only the listed row indices changed. Indices are viewport-relative
+    /// and sorted ascending.
+    Partial(Vec<u16>),
+    /// Every row must be considered dirty (scroll, resize, alt-screen
+    /// flip, theme change, or the adapter doesn't track row-level dirty
+    /// state). Callers should rebuild the full frame.
+    Full,
+}
+
 /// A snapshot of the VT grid the renderer walks to build one frame.
 pub trait FrameSource {
     /// (columns, rows) of the current grid.
@@ -126,6 +145,20 @@ pub trait FrameSource {
     /// Drive a visitor over every cell. The adapter is responsible for
     /// issuing calls in row-major order and clamping to `grid_size`.
     fn visit_cells(&mut self, visitor: &mut dyn CellVisitor);
+
+    /// Report which rows have changed since the last [`Self::clear_dirty`].
+    ///
+    /// The dirty set is preserved across repeated calls until explicitly
+    /// acknowledged — callers may sample it as many times as they like.
+    /// Default impl is [`DirtySnapshot::Full`], which is safe for adapters
+    /// that don't track row-level state.
+    fn dirty_rows(&mut self) -> DirtySnapshot {
+        DirtySnapshot::Full
+    }
+
+    /// Acknowledge the dirty set. After this call [`Self::dirty_rows`]
+    /// should report [`DirtySnapshot::Clean`] until the VT state changes.
+    fn clear_dirty(&mut self) {}
 
     /// Emit kitty graphics placements in the requested z-layer.
     ///

--- a/crates/seance-vt/src/frame_source.rs
+++ b/crates/seance-vt/src/frame_source.rs
@@ -9,8 +9,8 @@ use libghostty_vt::render::{CellIteration, CellIterator, CursorVisualStyle, RowI
 use libghostty_vt::style::{self, PaletteIndex, RgbColor};
 
 use crate::frame::{
-    CellAttrs, CellColor, CellView, CellVisitor, CursorInfo, CursorShape, FrameSource, ImageInfo,
-    ImageVisitor, PlacementLayer, PlacementSnapshot, PlacementVisitor,
+    CellAttrs, CellColor, CellView, CellVisitor, CursorInfo, CursorShape, DirtySnapshot,
+    FrameSource, ImageInfo, ImageVisitor, PlacementLayer, PlacementSnapshot, PlacementVisitor,
 };
 use crate::kitty_placeholder::{PLACEHOLDER_CP, diacritic_index};
 use crate::selection::GridPos;
@@ -68,6 +68,14 @@ impl FrameSource for LibGhosttyFrameSource<'_> {
 
     fn visit_cells(&mut self, visitor: &mut dyn CellVisitor) {
         let _ = walk(self.term, visitor);
+    }
+
+    fn dirty_rows(&mut self) -> DirtySnapshot {
+        self.term.dirty_snapshot().unwrap_or(DirtySnapshot::Full)
+    }
+
+    fn clear_dirty(&mut self) {
+        self.term.clear_dirty();
     }
 
     fn visit_placements(&mut self, layer: PlacementLayer, visitor: &mut dyn PlacementVisitor) {

--- a/crates/seance-vt/src/lib.rs
+++ b/crates/seance-vt/src/lib.rs
@@ -13,8 +13,8 @@ pub mod selection;
 mod terminal;
 
 pub use frame::{
-    CellAttrs, CellColor, CellView, CellVisitor, CursorInfo, CursorShape, FrameSource, ImageInfo,
-    ImageVisitor, PlacementLayer, PlacementSnapshot, PlacementVisitor,
+    CellAttrs, CellColor, CellView, CellVisitor, CursorInfo, CursorShape, DirtySnapshot,
+    FrameSource, ImageInfo, ImageVisitor, PlacementLayer, PlacementSnapshot, PlacementVisitor,
 };
 pub use frame_source::LibGhosttyFrameSource;
 pub use modes::TerminalModes;

--- a/crates/seance-vt/src/terminal.rs
+++ b/crates/seance-vt/src/terminal.rs
@@ -7,12 +7,13 @@ use std::sync::Once;
 
 use libghostty_vt::alloc::{Allocator, Bytes};
 use libghostty_vt::kitty::graphics::{self, DecodePng, DecodedImage};
-use libghostty_vt::render::{CellIterator, RowIterator};
+use libghostty_vt::render::{CellIterator, Dirty, RowIterator};
 use libghostty_vt::style::RgbColor;
 use libghostty_vt::terminal::{Mode, ScrollViewport};
 use libghostty_vt::{RenderState, Terminal as VtTerminal, TerminalOptions};
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 
+use crate::frame::DirtySnapshot;
 use crate::modes::TerminalModes;
 use crate::selection::{GridPos, Selection, SelectionGranularity};
 
@@ -69,6 +70,11 @@ fn install_png_decoder_once() {
 /// A terminal session: VT emulator, PTY, and text selection state.
 pub struct Terminal {
     vt: Box<VtTerminal<'static, 'static>>,
+    /// Persistent render state. libghostty-vt's dirty tracking only
+    /// works when the same render state is reused across frames — each
+    /// `update(vt)` drains the VT's dirty set into the render state, and
+    /// per-row flags remain until the caller clears them.
+    render_state: RenderState<'static>,
     response_buf: Rc<RefCell<Vec<u8>>>,
     reader: Box<dyn Read + Send>,
     writer: RefCell<Box<dyn Write + Send>>,
@@ -140,8 +146,11 @@ impl Terminal {
             }
         }
 
+        let render_state = RenderState::new().ok()?;
+
         Some(Self {
             vt,
+            render_state,
             response_buf,
             reader,
             writer: RefCell::new(writer),
@@ -335,6 +344,65 @@ impl Terminal {
 
     pub(crate) fn vt(&self) -> &VtTerminal<'static, 'static> {
         &self.vt
+    }
+
+    /// Drain the VT's dirty state into the persistent render state and
+    /// report what changed. The flags remain set on the render state (and
+    /// can be re-read) until [`Self::clear_dirty`] acknowledges them.
+    ///
+    /// Returns `None` only on FFI failure — callers should treat that as
+    /// "unknown, redraw everything" for safety.
+    pub(crate) fn dirty_snapshot(&mut self) -> Option<DirtySnapshot> {
+        let Self {
+            vt, render_state, ..
+        } = self;
+        let snapshot = render_state.update(&**vt).ok()?;
+        let global = snapshot.dirty().ok()?;
+        match global {
+            Dirty::Clean => Some(DirtySnapshot::Clean),
+            Dirty::Full => Some(DirtySnapshot::Full),
+            Dirty::Partial => {
+                let mut rows_iter = RowIterator::new().ok()?;
+                let mut iter = rows_iter.update(&snapshot).ok()?;
+                let mut out: Vec<u16> = Vec::new();
+                let mut idx: u16 = 0;
+                while let Some(row) = iter.next() {
+                    if row.dirty().unwrap_or(true) {
+                        out.push(idx);
+                    }
+                    idx += 1;
+                }
+                // Global "Partial" with no dirty rows can arise when only
+                // cursor / selection / cursor-color changed. Fold to Clean
+                // so callers can short-circuit the whole rebuild.
+                if out.is_empty() {
+                    Some(DirtySnapshot::Clean)
+                } else {
+                    Some(DirtySnapshot::Partial(out))
+                }
+            }
+        }
+    }
+
+    /// Clear both the global frame-dirty signal and every per-row flag on
+    /// the persistent render state. Call after consuming a dirty snapshot.
+    pub(crate) fn clear_dirty(&mut self) {
+        let Self {
+            vt, render_state, ..
+        } = self;
+        let Ok(snapshot) = render_state.update(&**vt) else {
+            return;
+        };
+        let _ = snapshot.set_dirty(Dirty::Clean);
+        let Ok(mut rows_iter) = RowIterator::new() else {
+            return;
+        };
+        let Ok(mut iter) = rows_iter.update(&snapshot) else {
+            return;
+        };
+        while let Some(row) = iter.next() {
+            let _ = row.set_dirty(false);
+        }
     }
 
     /// Cell pixel dimensions as last passed to `vt.resize()`. Both are

--- a/crates/seance-vt/src/terminal.rs
+++ b/crates/seance-vt/src/terminal.rs
@@ -353,10 +353,7 @@ impl Terminal {
     /// Returns `None` only on FFI failure — callers should treat that as
     /// "unknown, redraw everything" for safety.
     pub(crate) fn dirty_snapshot(&mut self) -> Option<DirtySnapshot> {
-        let Self {
-            vt, render_state, ..
-        } = self;
-        let snapshot = render_state.update(&**vt).ok()?;
+        let snapshot = self.render_state.update(&self.vt).ok()?;
         let global = snapshot.dirty().ok()?;
         match global {
             Dirty::Clean => Some(DirtySnapshot::Clean),
@@ -387,10 +384,7 @@ impl Terminal {
     /// Clear both the global frame-dirty signal and every per-row flag on
     /// the persistent render state. Call after consuming a dirty snapshot.
     pub(crate) fn clear_dirty(&mut self) {
-        let Self {
-            vt, render_state, ..
-        } = self;
-        let Ok(snapshot) = render_state.update(&**vt) else {
+        let Ok(snapshot) = self.render_state.update(&self.vt) else {
             return;
         };
         let _ = snapshot.set_dirty(Dirty::Clean);


### PR DESCRIPTION
## Summary
This PR adds dirty row tracking to the terminal rendering pipeline, enabling renderers to skip rebuild work for unchanged rows and only process rows that have actually changed since the last frame.

## Key Changes
- **Terminal dirty state management**: Added a persistent `RenderState` to the `Terminal` struct that maintains dirty tracking across frames. libghostty-vt's dirty tracking requires reusing the same render state instance, so this stores it as a field rather than creating it per-frame.

- **New dirty snapshot API**: Introduced `dirty_snapshot()` and `clear_dirty()` methods on `Terminal` that:
  - Drain the VT's dirty state into the persistent render state
  - Report what changed as a `DirtySnapshot` enum (Clean, Partial with row indices, or Full)
  - Allow callers to acknowledge the dirty set by clearing flags

- **FrameSource trait extension**: Added `dirty_rows()` and `clear_dirty()` methods to the `FrameSource` trait with safe defaults (Full dirty state) for adapters that don't track row-level changes.

- **LibGhosttyFrameSource implementation**: Wired up the new trait methods to delegate to the underlying `Terminal` dirty tracking.

- **DirtySnapshot enum**: New public type that summarizes which rows changed, enabling renderers to:
  - Skip work entirely when `Clean`
  - Rebuild only specific rows when `Partial`
  - Rebuild everything when `Full`

## Implementation Details
- The `DirtySnapshot::Partial` variant stores viewport-relative row indices in sorted ascending order
- When a global "Partial" dirty state has no dirty rows (e.g., only cursor/selection changed), it's folded to `Clean` to let callers short-circuit
- All FFI operations return `Option`, treating failures as "unknown, redraw everything" for safety