### PR TITLE
docs: expand commit and PR guidelines with detailed formatting rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,5 +108,18 @@ verbatim — do not append any auto-generated trailer.
 
 ## Branches
 
-Development branches follow `claude/<short-slug>-<suffix>`. Never push directly
-to `main`.
+Branch names follow Conventional Commits, mirroring the commit `type` and
+optional `scope`: `<type>/<short-kebab-summary>` or
+`<type>-<scope>/<short-kebab-summary>`.
+
+- `type` is one of the Conventional Commit types listed above.
+- The summary is lowercase, kebab-cased, and describes the change — not the
+  author or the agent.
+- No `claude/` (or other agent/author) prefix.
+- No random hash, timestamp, or session suffix at the end.
+- Keep it short; aim for ≤40 characters total.
+
+Examples: `feat/dirty-row-tracking`, `fix-cursor/honor-decscusr`,
+`docs/architecture-vt-section`, `refactor/split-platform-modules`.
+
+Never push directly to `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,42 @@ When picking up a sub-issue:
 
 Use Conventional Commits (<https://www.conventionalcommits.org/>) for every
 commit and PR title: `type(scope): summary`, with `type` drawn from `feat`,
-`fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`. Keep the
-subject line under 72 characters. Put the why (and any design narration that
-would otherwise leak into code comments) in the body.
+`fix`, `refactor`, `perf`, `docs`, `test`, `style`, `chore`, `build`, `ci`.
+Keep the subject line under 72 characters. Put the why (and any design
+narration that would otherwise leak into code comments) in the body.
+
+## Pull requests
+
+PRs opened by Claude MUST follow the same format as commits. The PR title is
+the subject; the PR body is the commit body. Apply these rules to both.
+
+### Subject (PR title / commit subject)
+
+- Conventional Commits: `type(scope): summary`. Scope is optional.
+- Allowed types: `feat`, `fix`, `refactor`, `docs`, `test`, `perf`, `style`,
+  `chore`, `build`, `ci`.
+- Imperative mood, no trailing period, lowercase after the type.
+- Aim for ≤50 characters; 72 is the hard limit (GitHub truncates beyond it).
+
+### Body (PR body / commit body)
+
+- Wrap every line at 72 columns.
+- Explain *why*, not *what*. The diff already shows what changed.
+- Separate the subject from the body with a blank line.
+- Footers (optional, last block): `Breaking-Change:`, `Refs: #<issue>`.
+
+### Forbidden in PRs and commits
+
+- No `Co-Authored-By:` lines.
+- No `Generated with` / `Created by Claude` / tool-attribution footers.
+- No emoji-prefixed footers (e.g. 🤖) or marketing taglines.
+- No links back to the agent session, chat URL, or any
+  `https://claude.ai/code/...` reference.
+- No HTML comments, no `<details>` collapsibles, no checkbox "test plan"
+  templates unless the user explicitly asks for one.
+
+When using the GitHub MCP tools to open a PR, pass the title and body
+verbatim — do not append any auto-generated trailer.
 
 ## Branches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,14 +69,14 @@ When picking up a sub-issue:
 
 Use Conventional Commits (<https://www.conventionalcommits.org/>) for every
 commit and PR title: `type(scope): summary`, with `type` drawn from `feat`,
-`fix`, `refactor`, `perf`, `docs`, `test`, `style`, `chore`, `build`, `ci`.
-Keep the subject line under 72 characters. Put the why (and any design
-narration that would otherwise leak into code comments) in the body.
+`fix`, `refactor`, `perf`, `docs`, `test`, `style`, `chore`, `build`, `ci`. Keep
+the subject line under 72 characters. Put the why (and any design narration that
+would otherwise leak into code comments) in the body.
 
 ## Pull requests
 
-PRs opened by Claude MUST follow the same format as commits. The PR title is
-the subject; the PR body is the commit body. Apply these rules to both.
+PRs opened by Claude MUST follow the same format as commits. The PR title is the
+subject; the PR body is the commit body. Apply these rules to both.
 
 ### Subject (PR title / commit subject)
 
@@ -89,7 +89,7 @@ the subject; the PR body is the commit body. Apply these rules to both.
 ### Body (PR body / commit body)
 
 - Wrap every line at 72 columns.
-- Explain *why*, not *what*. The diff already shows what changed.
+- Explain _why_, not _what_. The diff already shows what changed.
 - Separate the subject from the body with a blank line.
 - Footers (optional, last block): `Breaking-Change:`, `Refs: #<issue>`.
 
@@ -103,8 +103,8 @@ the subject; the PR body is the commit body. Apply these rules to both.
 - No HTML comments, no `<details>` collapsibles, no checkbox "test plan"
   templates unless the user explicitly asks for one.
 
-When using the GitHub MCP tools to open a PR, pass the title and body
-verbatim — do not append any auto-generated trailer.
+When using the GitHub MCP tools to open a PR, pass the title and body verbatim —
+do not append any auto-generated trailer.
 
 ## Branches
 


### PR DESCRIPTION
Clarify and expand the contribution guidelines for commits and pull requests
to provide more explicit formatting rules and examples.

This update adds:

- A new "Pull requests" section that establishes PRs must follow the same
  Conventional Commits format as individual commits, with the PR title as
  subject and PR body as commit body.
- Detailed subsections for subject and body formatting, including character
  limits (≤50 chars ideal, 72 hard limit), imperative mood requirements, and
  line wrapping at 72 columns.
- A comprehensive "Forbidden in PRs and commits" section that explicitly
  prohibits co-author lines, tool attribution footers, emoji prefixes,
  session/chat links, and auto-generated templates.
- Revised "Branches" section that replaces the old `claude/` prefix pattern
  with Conventional Commits-based naming (`type/summary` or
  `type-scope/summary`), with concrete examples and a 40-character target.

These changes provide clearer expectations for Claude-generated contributions
and ensure consistency with standard open-source practices.

https://claude.ai/code/session_01Rno9g4xJ3qidUYdnLQdfDD