### PR TITLE
Implement dirty region tracking for GPU buffer uploads

### DIFF
--- a/crates/seance-render/src/gpu/mod.rs
+++ b/crates/seance-render/src/gpu/mod.rs
@@ -4,4 +4,4 @@ mod pipeline;
 mod state;
 pub(crate) mod uniforms;
 
-pub(crate) use state::GpuState;
+pub(crate) use state::{CellFrame, GpuState};

--- a/crates/seance-render/src/gpu/state.rs
+++ b/crates/seance-render/src/gpu/state.rs
@@ -17,6 +17,14 @@ use seance_vt::{DirtySnapshot, FrameSource, PlacementLayer};
 const ATLAS_GRAYSCALE_FORMAT: TextureFormat = TextureFormat::R8Unorm;
 const ATLAS_COLOR_FORMAT: TextureFormat = TextureFormat::Rgba8Unorm;
 
+/// Per-frame cell data the GPU layer consumes — bundled to keep
+/// `render_frame`'s arg count down.
+pub(crate) struct CellFrame<'a> {
+    pub bg_cells: &'a [[u8; 4]],
+    pub text_cells: &'a [CellText],
+    pub dirty: &'a DirtySnapshot,
+}
+
 pub(crate) struct GpuState {
     surface: Surface<'static>,
     device: Device,
@@ -159,9 +167,7 @@ impl GpuState {
     pub(crate) fn render_frame(
         &mut self,
         frame_info: &FrameInfo,
-        bg_cells: &[[u8; 4]],
-        text_cells: &[CellText],
-        dirty: &DirtySnapshot,
+        cells: CellFrame<'_>,
         atlas: &GlyphAtlas,
         inputs: &RenderInputs,
         theme: &Theme,
@@ -176,7 +182,12 @@ impl GpuState {
         };
 
         self.upload_uniforms(frame_info, inputs, theme);
-        self.upload_cell_data(bg_cells, text_cells, dirty, frame_info.grid_cols);
+        self.upload_cell_data(
+            cells.bg_cells,
+            cells.text_cells,
+            cells.dirty,
+            frame_info.grid_cols,
+        );
         self.upload_atlas(atlas);
         self.ensure_atlas_bind_group();
 

--- a/crates/seance-render/src/gpu/state.rs
+++ b/crates/seance-render/src/gpu/state.rs
@@ -12,7 +12,7 @@ use crate::image::ImageRenderer;
 use crate::renderer::RenderInputs;
 use crate::text::{CellText, FrameInfo, GlyphAtlas};
 use seance_config::Theme;
-use seance_vt::{FrameSource, PlacementLayer};
+use seance_vt::{DirtySnapshot, FrameSource, PlacementLayer};
 
 const ATLAS_GRAYSCALE_FORMAT: TextureFormat = TextureFormat::R8Unorm;
 const ATLAS_COLOR_FORMAT: TextureFormat = TextureFormat::Rgba8Unorm;
@@ -161,6 +161,7 @@ impl GpuState {
         frame_info: &FrameInfo,
         bg_cells: &[[u8; 4]],
         text_cells: &[CellText],
+        dirty: &DirtySnapshot,
         atlas: &GlyphAtlas,
         inputs: &RenderInputs,
         theme: &Theme,
@@ -175,7 +176,7 @@ impl GpuState {
         };
 
         self.upload_uniforms(frame_info, inputs, theme);
-        self.upload_cell_data(bg_cells, text_cells);
+        self.upload_cell_data(bg_cells, text_cells, dirty, frame_info.grid_cols);
         self.upload_atlas(atlas);
         self.ensure_atlas_bind_group();
 
@@ -222,26 +223,84 @@ impl GpuState {
             .write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
     }
 
-    fn upload_cell_data(&mut self, bg_cells: &[[u8; 4]], text_cells: &[CellText]) {
-        if !bg_cells.is_empty() {
-            let data = bytemuck::cast_slice(bg_cells);
-            if self.bg_cells.upload(&self.device, &self.queue, data) {
-                self.bg_cells.bind_group =
-                    Some(self.device.create_bind_group(&BindGroupDescriptor {
-                        label: Some("bg_cells_bg"),
-                        layout: &self.pipelines.bg_cells_bgl,
-                        entries: &[BindGroupEntry {
-                            binding: 0,
-                            resource: self.bg_cells.buffer.as_ref().unwrap().as_entire_binding(),
-                        }],
-                    }));
+    fn upload_cell_data(
+        &mut self,
+        bg_cells: &[[u8; 4]],
+        text_cells: &[CellText],
+        dirty: &DirtySnapshot,
+        grid_cols: u16,
+    ) {
+        // `Clean` short-circuits both buffers — the GPU still holds last
+        // frame's data and the CPU rebuild is byte-identical, so the
+        // upload is wasted bandwidth. `text_instance_count` is intentionally
+        // left at its previous value (the count is unchanged on Clean).
+        if matches!(dirty, DirtySnapshot::Clean) {
+            return;
+        }
+
+        let bg_bytes: &[u8] = bytemuck::cast_slice(bg_cells);
+
+        // Partial upload is only safe when the existing buffer already
+        // covers the full slice. On first frame / resize the buffer is
+        // either absent or smaller, so degrade to Full and let
+        // `DynamicBuffer::upload` reallocate.
+        let bg_buffer_covers = self
+            .bg_cells
+            .buffer
+            .as_ref()
+            .is_some_and(|b| b.size() >= bg_bytes.len() as u64);
+
+        match dirty {
+            DirtySnapshot::Clean => unreachable!("handled above"),
+            DirtySnapshot::Full => {
+                self.upload_bg_full(bg_bytes);
+            }
+            DirtySnapshot::Partial(_) if !bg_buffer_covers => {
+                // Defensive: VT marks resize as Full so this path is
+                // unlikely in practice, but we handle it anyway.
+                self.upload_bg_full(bg_bytes);
+            }
+            DirtySnapshot::Partial(rows) => {
+                // `Terminal::dirty_snapshot` folds empty Partial -> Clean,
+                // so `rows` is non-empty here. Indices are sorted ascending,
+                // so first/last give a contiguous min..=max span.
+                let row_min = *rows.first().expect("non-empty Partial") as usize;
+                let row_max = *rows.last().expect("non-empty Partial") as usize;
+                let (offset, len) = bg_byte_range(row_min, row_max, grid_cols as usize);
+                let buffer = self
+                    .bg_cells
+                    .buffer
+                    .as_ref()
+                    .expect("bg_buffer_covers checked");
+                self.queue
+                    .write_buffer(buffer, offset, &bg_bytes[offset as usize..][..len]);
             }
         }
 
+        // text_cells is glyph-indexed (densely packed; a row → instance
+        // mapping isn't stable across frames), so the partial-by-row
+        // strategy doesn't apply. Re-upload the full buffer whenever the
+        // VT reported any change. Skipping on Clean is the dominant win.
         self.text_instance_count = text_cells.len() as u32;
         if !text_cells.is_empty() {
             self.text_instances
                 .upload(&self.device, &self.queue, bytemuck::cast_slice(text_cells));
+        }
+    }
+
+    fn upload_bg_full(&mut self, bg_bytes: &[u8]) {
+        if bg_bytes.is_empty() {
+            return;
+        }
+        if self.bg_cells.upload(&self.device, &self.queue, bg_bytes) {
+            self.bg_cells.bind_group = Some(self.device.create_bind_group(&BindGroupDescriptor {
+                label: Some("bg_cells_bg"),
+                layout: &self.pipelines.bg_cells_bgl,
+                entries: &[BindGroupEntry {
+                    binding: 0,
+                    resource: self.bg_cells.buffer.as_ref().unwrap().as_entire_binding(),
+                }],
+            }));
         }
     }
 
@@ -371,5 +430,39 @@ impl GpuState {
             PlacementLayer::AboveText,
             &self.uniform_bind_group,
         );
+    }
+}
+
+/// Translate an inclusive row range into a byte `(offset, len)` over a
+/// row-major `[u8; 4]`-per-cell buffer.
+fn bg_byte_range(row_min: usize, row_max: usize, grid_cols: usize) -> (u64, usize) {
+    debug_assert!(row_min <= row_max);
+    let stride = grid_cols * size_of::<[u8; 4]>();
+    let offset = (row_min * stride) as u64;
+    let len = (row_max - row_min + 1) * stride;
+    (offset, len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bg_byte_range;
+
+    #[test]
+    fn bg_byte_range_single_row_zero() {
+        assert_eq!(bg_byte_range(0, 0, 80), (0, 80 * 4));
+    }
+
+    #[test]
+    fn bg_byte_range_single_row_n() {
+        let (offset, len) = bg_byte_range(7, 7, 80);
+        assert_eq!(offset, 7 * 80 * 4);
+        assert_eq!(len, 80 * 4);
+    }
+
+    #[test]
+    fn bg_byte_range_inclusive_span() {
+        let (offset, len) = bg_byte_range(5, 10, 80);
+        assert_eq!(offset, 5 * 80 * 4);
+        assert_eq!(len, 6 * 80 * 4); // rows 5..=10 inclusive
     }
 }

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -4,8 +4,8 @@ use seance_config::Theme;
 use seance_vt::{FrameSource, GridPos};
 use winit::window::Window;
 
-use crate::gpu::GpuState;
 pub use crate::gpu::uniforms::CursorShape;
+use crate::gpu::{CellFrame, GpuState};
 use crate::text::backend::TextBackend;
 use crate::text::cosmic::CosmicTextBackend;
 use crate::text::{BuildFrameConfig, CellBuilder};
@@ -142,9 +142,11 @@ impl TerminalRenderer {
         };
         self.gpu.render_frame(
             fi,
-            self.cell_builder.bg_cells(),
-            self.cell_builder.text_cells(),
-            self.cell_builder.last_dirty(),
+            CellFrame {
+                bg_cells: self.cell_builder.bg_cells(),
+                text_cells: self.cell_builder.text_cells(),
+                dirty: self.cell_builder.last_dirty(),
+            },
             self.cell_builder.atlas(),
             inputs,
             &self.theme,

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -144,6 +144,7 @@ impl TerminalRenderer {
             fi,
             self.cell_builder.bg_cells(),
             self.cell_builder.text_cells(),
+            self.cell_builder.last_dirty(),
             self.cell_builder.atlas(),
             inputs,
             &self.theme,

--- a/crates/seance-render/src/text/cell_builder.rs
+++ b/crates/seance-render/src/text/cell_builder.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 use rustc_hash::FxBuildHasher;
 use seance_config::Theme;
-use seance_vt::{CellColor, CellView, CellVisitor, FrameSource};
+use seance_vt::{CellColor, CellView, CellVisitor, DirtySnapshot, FrameSource};
 
 use super::atlas::{AtlasEntry, GlyphAtlas};
 use super::backend::{FontAttrs, GlyphFormat, GlyphId, ShapedGlyph, TextBackend};
@@ -96,6 +96,7 @@ pub struct CellBuilder {
     requests: Vec<CellRequest>,
     shape_scratch: Vec<ShapedGlyph>,
     last_frame: Option<FrameInfo>,
+    last_dirty: DirtySnapshot,
 }
 
 impl CellBuilder {
@@ -108,6 +109,9 @@ impl CellBuilder {
             requests: Vec::new(),
             shape_scratch: Vec::new(),
             last_frame: None,
+            // First frame must be a full upload — there's nothing on the
+            // GPU yet for a `Partial` write to layer onto.
+            last_dirty: DirtySnapshot::Full,
         }
     }
 
@@ -117,6 +121,13 @@ impl CellBuilder {
         backend: &mut dyn TextBackend,
         config: BuildFrameConfig<'_>,
     ) {
+        // Sample the dirty set first so the rest of the build can mutate
+        // the source freely. The snapshot is owned by the builder; the
+        // matching `clear_dirty` call below acknowledges it on the VT
+        // side so the next frame reports only post-snapshot changes.
+        self.last_dirty = source.dirty_rows();
+        source.clear_dirty();
+
         let (baseline, geom) = {
             let m = backend.metrics();
             let g = geometry(
@@ -187,6 +198,10 @@ impl CellBuilder {
 
     pub fn last_frame(&self) -> Option<&FrameInfo> {
         self.last_frame.as_ref()
+    }
+
+    pub fn last_dirty(&self) -> &DirtySnapshot {
+        &self.last_dirty
     }
 }
 
@@ -343,12 +358,33 @@ impl CellVisitor for WalkVisitor<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::text::backend::{
+        CellMetrics, FontAttrs, GlyphId, RasterizedGlyph, ShapedGlyph, TextBackend,
+    };
     use seance_vt::{CellAttrs, CellColor, CellVisitor, CursorInfo, GridPos};
 
     struct FakeFrame<'a> {
         cols: u16,
         rows: u16,
         cells: &'a [(&'a str, CellColor, CellColor, CellAttrs)],
+        dirty: DirtySnapshot,
+        clear_count: u32,
+    }
+
+    impl<'a> FakeFrame<'a> {
+        fn new(
+            cols: u16,
+            rows: u16,
+            cells: &'a [(&'a str, CellColor, CellColor, CellAttrs)],
+        ) -> Self {
+            Self {
+                cols,
+                rows,
+                cells,
+                dirty: DirtySnapshot::Full,
+                clear_count: 0,
+            }
+        }
     }
 
     impl FrameSource for FakeFrame<'_> {
@@ -376,6 +412,87 @@ mod tests {
                 );
             }
         }
+        fn dirty_rows(&mut self) -> DirtySnapshot {
+            self.dirty.clone()
+        }
+        fn clear_dirty(&mut self) {
+            self.clear_count += 1;
+            self.dirty = DirtySnapshot::Clean;
+        }
+    }
+
+    struct StubBackend {
+        metrics: CellMetrics,
+    }
+
+    impl StubBackend {
+        fn new() -> Self {
+            Self {
+                metrics: CellMetrics {
+                    cell_width: 10.0,
+                    cell_height: 20.0,
+                    baseline: 16.0,
+                },
+            }
+        }
+    }
+
+    impl TextBackend for StubBackend {
+        fn metrics(&self) -> &CellMetrics {
+            &self.metrics
+        }
+        fn set_font_size(&mut self, _points: f32) {}
+        fn set_scale(&mut self, _scale: f64) {}
+        fn set_adjust_cell_height(&mut self, _value: Option<&str>) {}
+        fn shape_cell(&mut self, _text: &str, _attrs: FontAttrs, _out: &mut Vec<ShapedGlyph>) {}
+        fn rasterize(&mut self, _glyph: GlyphId) -> Option<RasterizedGlyph> {
+            None
+        }
+    }
+
+    fn build_config(theme: &Theme) -> BuildFrameConfig<'_> {
+        BuildFrameConfig {
+            surface_width: 100,
+            surface_height: 100,
+            window_padding: [0, 0],
+            theme,
+            bg_color: [0, 0, 0, 255],
+            min_contrast: 1.0,
+        }
+    }
+
+    #[test]
+    fn build_frame_captures_dirty_snapshot_and_acknowledges_source() {
+        let theme = Theme::blank();
+        let cells = [(
+            "A",
+            CellColor::Default,
+            CellColor::Default,
+            CellAttrs::default(),
+        )];
+        let mut source = FakeFrame::new(1, 1, &cells);
+        source.dirty = DirtySnapshot::Partial(vec![0]);
+        let mut backend = StubBackend::new();
+        let mut builder = CellBuilder::new();
+
+        builder.build_frame(&mut source, &mut backend, build_config(&theme));
+
+        assert_eq!(*builder.last_dirty(), DirtySnapshot::Partial(vec![0]));
+        assert_eq!(source.clear_count, 1);
+        // Sticky-clear simulation: the second build sees Clean because
+        // the fake reset itself in clear_dirty.
+        builder.build_frame(&mut source, &mut backend, build_config(&theme));
+        assert_eq!(*builder.last_dirty(), DirtySnapshot::Clean);
+        assert_eq!(source.clear_count, 2);
+    }
+
+    #[test]
+    fn build_frame_first_call_defaults_last_dirty_to_full_until_sampled() {
+        // Before any build_frame, last_dirty is Full so the first GPU
+        // upload is the full path. After build_frame, last_dirty mirrors
+        // whatever the source reported.
+        let builder = CellBuilder::new();
+        assert_eq!(*builder.last_dirty(), DirtySnapshot::Full);
     }
 
     #[test]
@@ -401,11 +518,7 @@ mod tests {
                 CellAttrs::default(),
             ),
         ];
-        let mut source = FakeFrame {
-            cols: 3,
-            rows: 1,
-            cells: &cells,
-        };
+        let mut source = FakeFrame::new(3, 1, &cells);
         let geom = FrameGeometry {
             cell_width: 10.0,
             cell_height: 20.0,
@@ -441,11 +554,7 @@ mod tests {
                 ..CellAttrs::default()
             },
         )];
-        let mut source = FakeFrame {
-            cols: 1,
-            rows: 1,
-            cells: &cells,
-        };
+        let mut source = FakeFrame::new(1, 1, &cells);
         let geom = FrameGeometry {
             cell_width: 10.0,
             cell_height: 20.0,
@@ -474,11 +583,7 @@ mod tests {
                 ..CellAttrs::default()
             },
         )];
-        let mut source = FakeFrame {
-            cols: 1,
-            rows: 1,
-            cells: &cells,
-        };
+        let mut source = FakeFrame::new(1, 1, &cells);
         let geom = FrameGeometry {
             cell_width: 10.0,
             cell_height: 20.0,
@@ -510,11 +615,7 @@ mod tests {
                 ..CellAttrs::default()
             },
         )];
-        let mut source = FakeFrame {
-            cols: 1,
-            rows: 1,
-            cells: &cells,
-        };
+        let mut source = FakeFrame::new(1, 1, &cells);
         let geom = FrameGeometry {
             cell_width: 10.0,
             cell_height: 20.0,
@@ -544,11 +645,7 @@ mod tests {
                 ..CellAttrs::default()
             },
         )];
-        let mut source = FakeFrame {
-            cols: 1,
-            rows: 1,
-            cells: &cells,
-        };
+        let mut source = FakeFrame::new(1, 1, &cells);
         let geom = FrameGeometry {
             cell_width: 10.0,
             cell_height: 20.0,
@@ -574,11 +671,7 @@ mod tests {
     #[test]
     fn geometry_honors_user_padding() {
         let cells: [(&str, CellColor, CellColor, CellAttrs); 0] = [];
-        let mut source = FakeFrame {
-            cols: 10,
-            rows: 5,
-            cells: &cells,
-        };
+        let mut source = FakeFrame::new(10, 5, &cells);
         let g = geometry(&mut source, 10.0, 20.0, 200, 200, [12, 6]);
         assert_eq!(g.grid_padding, [12.0, 6.0, 12.0, 6.0]);
     }
@@ -586,11 +679,7 @@ mod tests {
     #[test]
     fn geometry_clamps_padding_to_surface() {
         let cells: [(&str, CellColor, CellColor, CellAttrs); 0] = [];
-        let mut source = FakeFrame {
-            cols: 10,
-            rows: 5,
-            cells: &cells,
-        };
+        let mut source = FakeFrame::new(10, 5, &cells);
         let g = geometry(&mut source, 10.0, 20.0, 110, 110, [50, 40]);
         assert_eq!(g.grid_padding[0], 10.0);
         assert_eq!(g.grid_padding[1], 10.0);


### PR DESCRIPTION
## Summary
This PR implements dirty region tracking to optimize GPU buffer uploads by only updating changed portions of the screen rather than re-uploading entire buffers every frame.

## Key Changes

- **CellBuilder dirty snapshot tracking**: Added `last_dirty` field to `CellBuilder` to capture and store the dirty region state from the VT source at the start of each frame build. The snapshot is sampled before any mutations and acknowledged via `clear_dirty()` to ensure the next frame only reports post-snapshot changes.

- **GPU state partial upload support**: Enhanced `GpuState::upload_cell_data()` to handle three dirty states:
  - `Clean`: Skip all uploads (GPU buffer is already current)
  - `Full`: Re-upload entire background cell buffer
  - `Partial(rows)`: Upload only the affected row range as a contiguous byte span

- **Background cell byte range calculation**: Added `bg_byte_range()` helper function to translate an inclusive row range into proper byte offsets and lengths for row-major `[u8; 4]`-per-cell buffers.

- **Text instance buffer handling**: Text instances continue to use full re-upload on any change since they're glyph-indexed (densely packed) and don't have a stable row-to-instance mapping across frames.

- **Test infrastructure**: 
  - Extended `FakeFrame` test fixture with dirty snapshot and clear count tracking
  - Added `StubBackend` for testing without a real text backend
  - New tests verify dirty snapshot capture/acknowledgment and byte range calculations

## Implementation Details

- First frame defaults to `DirtySnapshot::Full` to ensure complete GPU initialization
- Partial uploads are degraded to Full if the existing buffer is too small (e.g., after resize)
- The dirty snapshot is sampled at the very start of `build_frame()` before any source mutations, ensuring consistency
- Byte offset calculations account for the row-major layout with 4-byte cells per grid position

https://claude.ai/code/session_01TgJFNyPXoRXhM7b8idXP2D