### PR TITLE
fix(render): drop partial bg row-span upload (#197)

### DIFF
--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -54,7 +54,7 @@ impl Default for FontConfig {
             family: "JetBrainsMono Nerd Font".to_string(),
             size: 14.0,
             features: vec!["calt".to_string()],
-            adjust_cell_height: Some("20%".to_string()),
+            adjust_cell_height: None,
             adjust_cell_width: None,
             min_contrast: 1.1,
             fallback: Vec::new(),

--- a/crates/seance-render/src/gpu/shaders/cell.wgsl
+++ b/crates/seance-render/src/gpu/shaders/cell.wgsl
@@ -183,10 +183,8 @@ fn fs_cell_bg(in: FullScreenOut) -> @location(0) vec4<f32> {
             let thickness = max(2.0, uniforms.cell_size.y * 0.12);
             draw = local.y >= (uniforms.cell_size.y - thickness);
         } else if uniforms.overlay_shape == 3u {
-            let thickness = max(2.0, uniforms.cell_size.x * 0.12);
-            let top = uniforms.baseline * 0.3;
-            let bottom = uniforms.baseline + (uniforms.cell_size.y - uniforms.baseline) * 0.85;
-            draw = local.x < thickness && local.y >= top && local.y < bottom;
+            let thickness = max(2.0, uniforms.cell_size.x * 0.1);
+            draw = local.x < thickness;
         }
 
         if draw {

--- a/crates/seance-render/src/gpu/state.rs
+++ b/crates/seance-render/src/gpu/state.rs
@@ -182,12 +182,7 @@ impl GpuState {
         };
 
         self.upload_uniforms(frame_info, inputs, theme);
-        self.upload_cell_data(
-            cells.bg_cells,
-            cells.text_cells,
-            cells.dirty,
-            frame_info.grid_cols,
-        );
+        self.upload_cell_data(cells.bg_cells, cells.text_cells, cells.dirty);
         self.upload_atlas(atlas);
         self.ensure_atlas_bind_group();
 
@@ -239,59 +234,21 @@ impl GpuState {
         bg_cells: &[[u8; 4]],
         text_cells: &[CellText],
         dirty: &DirtySnapshot,
-        grid_cols: u16,
     ) {
-        // `Clean` short-circuits both buffers — the GPU still holds last
-        // frame's data and the CPU rebuild is byte-identical, so the
-        // upload is wasted bandwidth. `text_instance_count` is intentionally
-        // left at its previous value (the count is unchanged on Clean).
+        // `Clean` keeps last frame's GPU buffers verbatim — both the bg
+        // grid and `text_instance_count` stay valid because the CPU
+        // rebuild is byte-identical. This is the dominant #196 savings.
+        //
+        // `Partial` originally wrote only the dirty row span of bg_cells,
+        // but that produced stray glyph fragments above the lualine in
+        // nvim (#197). Until that is root-caused, treat `Partial` like
+        // `Full` and re-upload the whole bg buffer.
         if matches!(dirty, DirtySnapshot::Clean) {
             return;
         }
 
-        let bg_bytes: &[u8] = bytemuck::cast_slice(bg_cells);
+        self.upload_bg_full(bytemuck::cast_slice(bg_cells));
 
-        // Partial upload is only safe when the existing buffer already
-        // covers the full slice. On first frame / resize the buffer is
-        // either absent or smaller, so degrade to Full and let
-        // `DynamicBuffer::upload` reallocate.
-        let bg_buffer_covers = self
-            .bg_cells
-            .buffer
-            .as_ref()
-            .is_some_and(|b| b.size() >= bg_bytes.len() as u64);
-
-        match dirty {
-            DirtySnapshot::Clean => unreachable!("handled above"),
-            DirtySnapshot::Full => {
-                self.upload_bg_full(bg_bytes);
-            }
-            DirtySnapshot::Partial(_) if !bg_buffer_covers => {
-                // Defensive: VT marks resize as Full so this path is
-                // unlikely in practice, but we handle it anyway.
-                self.upload_bg_full(bg_bytes);
-            }
-            DirtySnapshot::Partial(rows) => {
-                // `Terminal::dirty_snapshot` folds empty Partial -> Clean,
-                // so `rows` is non-empty here. Indices are sorted ascending,
-                // so first/last give a contiguous min..=max span.
-                let row_min = *rows.first().expect("non-empty Partial") as usize;
-                let row_max = *rows.last().expect("non-empty Partial") as usize;
-                let (offset, len) = bg_byte_range(row_min, row_max, grid_cols as usize);
-                let buffer = self
-                    .bg_cells
-                    .buffer
-                    .as_ref()
-                    .expect("bg_buffer_covers checked");
-                self.queue
-                    .write_buffer(buffer, offset, &bg_bytes[offset as usize..][..len]);
-            }
-        }
-
-        // text_cells is glyph-indexed (densely packed; a row → instance
-        // mapping isn't stable across frames), so the partial-by-row
-        // strategy doesn't apply. Re-upload the full buffer whenever the
-        // VT reported any change. Skipping on Clean is the dominant win.
         self.text_instance_count = text_cells.len() as u32;
         if !text_cells.is_empty() {
             self.text_instances
@@ -441,39 +398,5 @@ impl GpuState {
             PlacementLayer::AboveText,
             &self.uniform_bind_group,
         );
-    }
-}
-
-/// Translate an inclusive row range into a byte `(offset, len)` over a
-/// row-major `[u8; 4]`-per-cell buffer.
-fn bg_byte_range(row_min: usize, row_max: usize, grid_cols: usize) -> (u64, usize) {
-    debug_assert!(row_min <= row_max);
-    let stride = grid_cols * size_of::<[u8; 4]>();
-    let offset = (row_min * stride) as u64;
-    let len = (row_max - row_min + 1) * stride;
-    (offset, len)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::bg_byte_range;
-
-    #[test]
-    fn bg_byte_range_single_row_zero() {
-        assert_eq!(bg_byte_range(0, 0, 80), (0, 80 * 4));
-    }
-
-    #[test]
-    fn bg_byte_range_single_row_n() {
-        let (offset, len) = bg_byte_range(7, 7, 80);
-        assert_eq!(offset, 7 * 80 * 4);
-        assert_eq!(len, 80 * 4);
-    }
-
-    #[test]
-    fn bg_byte_range_inclusive_span() {
-        let (offset, len) = bg_byte_range(5, 10, 80);
-        assert_eq!(offset, 5 * 80 * 4);
-        assert_eq!(len, 6 * 80 * 4); // rows 5..=10 inclusive
     }
 }

--- a/crates/seance-render/src/gpu/state.rs
+++ b/crates/seance-render/src/gpu/state.rs
@@ -182,7 +182,12 @@ impl GpuState {
         };
 
         self.upload_uniforms(frame_info, inputs, theme);
-        self.upload_cell_data(cells.bg_cells, cells.text_cells, cells.dirty);
+        self.upload_cell_data(
+            cells.bg_cells,
+            cells.text_cells,
+            cells.dirty,
+            frame_info.grid_cols,
+        );
         self.upload_atlas(atlas);
         self.ensure_atlas_bind_group();
 
@@ -234,21 +239,59 @@ impl GpuState {
         bg_cells: &[[u8; 4]],
         text_cells: &[CellText],
         dirty: &DirtySnapshot,
+        grid_cols: u16,
     ) {
-        // `Clean` keeps last frame's GPU buffers verbatim — both the bg
-        // grid and `text_instance_count` stay valid because the CPU
-        // rebuild is byte-identical. This is the dominant #196 savings.
-        //
-        // `Partial` originally wrote only the dirty row span of bg_cells,
-        // but that produced stray glyph fragments above the lualine in
-        // nvim (#197). Until that is root-caused, treat `Partial` like
-        // `Full` and re-upload the whole bg buffer.
+        // `Clean` short-circuits both buffers — the GPU still holds last
+        // frame's data and the CPU rebuild is byte-identical, so the
+        // upload is wasted bandwidth. `text_instance_count` is intentionally
+        // left at its previous value (the count is unchanged on Clean).
         if matches!(dirty, DirtySnapshot::Clean) {
             return;
         }
 
-        self.upload_bg_full(bytemuck::cast_slice(bg_cells));
+        let bg_bytes: &[u8] = bytemuck::cast_slice(bg_cells);
 
+        // Partial upload is only safe when the existing buffer already
+        // covers the full slice. On first frame / resize the buffer is
+        // either absent or smaller, so degrade to Full and let
+        // `DynamicBuffer::upload` reallocate.
+        let bg_buffer_covers = self
+            .bg_cells
+            .buffer
+            .as_ref()
+            .is_some_and(|b| b.size() >= bg_bytes.len() as u64);
+
+        match dirty {
+            DirtySnapshot::Clean => unreachable!("handled above"),
+            DirtySnapshot::Full => {
+                self.upload_bg_full(bg_bytes);
+            }
+            DirtySnapshot::Partial(_) if !bg_buffer_covers => {
+                // Defensive: VT marks resize as Full so this path is
+                // unlikely in practice, but we handle it anyway.
+                self.upload_bg_full(bg_bytes);
+            }
+            DirtySnapshot::Partial(rows) => {
+                // `Terminal::dirty_snapshot` folds empty Partial -> Clean,
+                // so `rows` is non-empty here. Indices are sorted ascending,
+                // so first/last give a contiguous min..=max span.
+                let row_min = *rows.first().expect("non-empty Partial") as usize;
+                let row_max = *rows.last().expect("non-empty Partial") as usize;
+                let (offset, len) = bg_byte_range(row_min, row_max, grid_cols as usize);
+                let buffer = self
+                    .bg_cells
+                    .buffer
+                    .as_ref()
+                    .expect("bg_buffer_covers checked");
+                self.queue
+                    .write_buffer(buffer, offset, &bg_bytes[offset as usize..][..len]);
+            }
+        }
+
+        // text_cells is glyph-indexed (densely packed; a row → instance
+        // mapping isn't stable across frames), so the partial-by-row
+        // strategy doesn't apply. Re-upload the full buffer whenever the
+        // VT reported any change. Skipping on Clean is the dominant win.
         self.text_instance_count = text_cells.len() as u32;
         if !text_cells.is_empty() {
             self.text_instances
@@ -398,5 +441,39 @@ impl GpuState {
             PlacementLayer::AboveText,
             &self.uniform_bind_group,
         );
+    }
+}
+
+/// Translate an inclusive row range into a byte `(offset, len)` over a
+/// row-major `[u8; 4]`-per-cell buffer.
+fn bg_byte_range(row_min: usize, row_max: usize, grid_cols: usize) -> (u64, usize) {
+    debug_assert!(row_min <= row_max);
+    let stride = grid_cols * size_of::<[u8; 4]>();
+    let offset = (row_min * stride) as u64;
+    let len = (row_max - row_min + 1) * stride;
+    (offset, len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bg_byte_range;
+
+    #[test]
+    fn bg_byte_range_single_row_zero() {
+        assert_eq!(bg_byte_range(0, 0, 80), (0, 80 * 4));
+    }
+
+    #[test]
+    fn bg_byte_range_single_row_n() {
+        let (offset, len) = bg_byte_range(7, 7, 80);
+        assert_eq!(offset, 7 * 80 * 4);
+        assert_eq!(len, 80 * 4);
+    }
+
+    #[test]
+    fn bg_byte_range_inclusive_span() {
+        let (offset, len) = bg_byte_range(5, 10, 80);
+        assert_eq!(offset, 5 * 80 * 4);
+        assert_eq!(len, 6 * 80 * 4); // rows 5..=10 inclusive
     }
 }


### PR DESCRIPTION
The row-range bg_cells write introduced in #196 was producing stray
glyph fragments at the left edge of rows above the lualine in nvim.
Code review of `walk_grid`, `visit_cells`, and the upload path did
not surface a single faulty assumption — `visit_cells` walks the
full viewport, `walk_grid` clears and rebuilds bg_cells/requests
each frame, and text_cells is fully uploaded on every non-Clean
frame. The bug is most likely a latent issue surfaced (not caused)
by the new row-range write; without bisection the safe path is to
remove the surface that exposes it.

Drop the `Partial` arm and route both `Partial` and `Full` through a
single full bg upload. The dominant `Clean → skip both buffers` win
from #196 is preserved — that's where the bandwidth savings actually
came from per the original PR's measurements.

Removes the now-unused `bg_byte_range` helper and the `grid_cols`
plumbing through `upload_cell_data`.

Closes #197