### PR TITLE
Move PTY reader to dedicated thread, replace polling with deadline scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,6 @@ dependencies = [
 name = "seance-vt"
 version = "0.1.0"
 dependencies = [
- "libc",
  "libghostty-vt",
  "log",
  "png",

--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -25,15 +25,15 @@ use seance_render::{RenderInputs, RendererConfig, TerminalRenderer};
 use seance_vt::{CursorShape as VtCursorShape, FrameSource, LibGhosttyFrameSource, Terminal};
 
 use crate::UserEvent;
+use crate::io::spawn_pty_reader;
 use crate::keybinds::Keybinds;
 use crate::platform;
 use crate::watcher::ConfigWatcher;
 use crate::window_state::WindowState;
 
-const POLL_INTERVAL: Duration = Duration::from_millis(4);
-// Half-period of the cursor blink cycle; on + off = 1 s. The tick rides on
-// POLL_INTERVAL wakeups — once M2 #24 lands we should drive it from the
-// deadline scheduler instead.
+/// Half-period of the cursor blink cycle; on + off = 1 s. Drives the
+/// deadline scheduler — when blink is enabled, the next animation wake
+/// is `last_blink_edge + BLINK_HALF_PERIOD`.
 const BLINK_HALF_PERIOD: Duration = Duration::from_millis(500);
 
 pub(crate) struct App {
@@ -103,7 +103,9 @@ impl App {
         ws.renderer.render(&ws.render_inputs);
     }
 
-    fn tick_blink(&mut self) {
+    /// Advance the cursor blink state if we have crossed an edge. Called
+    /// from `about_to_wait` after the deadline-scheduled wake fires.
+    fn step_blink(&mut self) {
         let Some(ws) = self.window_state.as_mut() else {
             return;
         };
@@ -118,6 +120,24 @@ impl App {
             ws.blink_on = !ws.blink_on;
             ws.last_blink_edge = Instant::now();
             ws.mark_dirty();
+        }
+    }
+
+    /// Earliest instant at which any animation source needs the next
+    /// wake. `None` means the terminal is idle — `about_to_wait` will
+    /// drop into `ControlFlow::Wait` and the OS suspends us until either
+    /// a window event arrives or the IO thread signals via the proxy.
+    fn next_animation_deadline(&self) -> Option<Instant> {
+        let ws = self.window_state.as_ref()?;
+        // Occluded windows skip rendering anyway, so don't bother
+        // running the blink cycle while the window is hidden.
+        if ws.occluded {
+            return None;
+        }
+        if self.config.cursor.blink {
+            Some(ws.last_blink_edge + BLINK_HALF_PERIOD)
+        } else {
+            None
         }
     }
 }
@@ -176,6 +196,14 @@ impl ApplicationHandler<UserEvent> for App {
         // still override on subsequent frames.
         term.set_cursor_shape(vt_shape_from_config(self.config.cursor.style));
 
+        // Move the PTY reader onto a dedicated thread; from here the UI
+        // wakes only when the IO thread forwards `PtyData` / `PtyExited`
+        // through the proxy or when an animation deadline fires.
+        let reader = term
+            .take_reader()
+            .expect("Terminal::spawn must hand out the PTY reader");
+        spawn_pty_reader(reader, self.proxy.clone());
+
         let render_inputs = RenderInputs {
             cursor_shape: self.config.cursor.style.into(),
             ..RenderInputs::default()
@@ -193,10 +221,19 @@ impl ApplicationHandler<UserEvent> for App {
         }
     }
 
-    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: UserEvent) {
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: UserEvent) {
         match event {
             UserEvent::ConfigFileChanged => self.reload_config(),
             UserEvent::ThemeFileChanged(path) => self.on_theme_file_changed(&path),
+            UserEvent::PtyData(bytes) => {
+                if let Some(ws) = self.ws_mut() {
+                    ws.feed_pty(&bytes);
+                }
+            }
+            UserEvent::PtyExited => {
+                self.window_state = None;
+                event_loop.exit();
+            }
         }
     }
 
@@ -241,23 +278,25 @@ impl ApplicationHandler<UserEvent> for App {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        if let Some(ws) = self.ws_mut()
-            && !ws.poll_pty()
-        {
-            self.window_state = None;
-        }
         if self.window_state.is_none() {
             event_loop.exit();
             return;
         }
-        self.tick_blink();
+        self.step_blink();
         if let Some(ws) = self.window_state.as_ref()
             && ws.content_dirty
             && !ws.occluded
         {
             ws.request_redraw();
         }
-        event_loop.set_control_flow(ControlFlow::wait_duration(POLL_INTERVAL));
+        // Deadline-scheduled redraw: sleep until the next animation
+        // edge, or fully `Wait` when nothing is animating. PTY output
+        // wakes us out-of-band via `UserEvent::PtyData` from the reader
+        // thread, so an idle terminal really does park the event loop.
+        match self.next_animation_deadline() {
+            Some(deadline) => event_loop.set_control_flow(ControlFlow::WaitUntil(deadline)),
+            None => event_loop.set_control_flow(ControlFlow::Wait),
+        }
     }
 }
 

--- a/crates/seance-app/src/io.rs
+++ b/crates/seance-app/src/io.rs
@@ -1,0 +1,46 @@
+//! PTY reader thread.
+//!
+//! Owns the blocking `read()` on the master PTY and forwards bytes to the
+//! UI thread via the winit `EventLoopProxy`. Without this split the event
+//! loop has to wake periodically just to drain the PTY, which is the
+//! 250 Hz poll the deadline scheduler (#24) is replacing.
+
+use std::io::Read;
+
+use winit::event_loop::EventLoopProxy;
+
+use seance_vt::Terminal;
+
+use crate::UserEvent;
+
+/// Spawn a thread that drains the PTY reader and forwards every chunk to
+/// the UI via `proxy`. The thread exits on EOF or an unrecoverable read
+/// error after sending [`UserEvent::PtyExited`]; if the proxy is dead
+/// (event loop already gone) it exits silently.
+pub(crate) fn spawn_pty_reader(mut reader: Box<dyn Read + Send>, proxy: EventLoopProxy<UserEvent>) {
+    std::thread::Builder::new()
+        .name("seance-pty-reader".into())
+        .spawn(move || {
+            let mut buf = vec![0u8; Terminal::READ_CHUNK_SIZE];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => {
+                        let _ = proxy.send_event(UserEvent::PtyExited);
+                        return;
+                    }
+                    Ok(n) => {
+                        let chunk = buf[..n].to_vec();
+                        if proxy.send_event(UserEvent::PtyData(chunk)).is_err() {
+                            return;
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(_) => {
+                        let _ = proxy.send_event(UserEvent::PtyExited);
+                        return;
+                    }
+                }
+            }
+        })
+        .expect("failed to spawn pty reader thread");
+}

--- a/crates/seance-app/src/main.rs
+++ b/crates/seance-app/src/main.rs
@@ -6,6 +6,7 @@ mod app;
 mod apply;
 mod command;
 mod events;
+mod io;
 mod keybinds;
 mod mouse;
 mod platform;
@@ -15,15 +16,23 @@ mod window_state;
 
 use app::App;
 
-/// Events forwarded from the config watcher into the winit event loop. Using
-/// `EventLoopProxy` keeps reloads single-threaded with rendering — no torn
-/// reads of `Config` mid-frame.
+/// Events forwarded from background threads into the winit event loop.
+/// Using `EventLoopProxy` keeps every off-thread signal — config reloads,
+/// PTY output, child exit — funnelled onto the single UI thread that owns
+/// the renderer and VT, so there are no torn reads of `Config` or races
+/// against frame state.
 #[derive(Debug, Clone)]
 pub enum UserEvent {
     /// `config.toml` at `$XDG_CONFIG_HOME/seance/` changed.
     ConfigFileChanged,
     /// A file under `$XDG_CONFIG_HOME/seance/themes/` changed.
     ThemeFileChanged(PathBuf),
+    /// A chunk of PTY output read by the reader thread. Drives the VT and
+    /// the redraw request — every wake from idle goes through here.
+    PtyData(Vec<u8>),
+    /// The PTY reader thread saw EOF or an unrecoverable error. The child
+    /// has gone; the UI tears down its window state and exits.
+    PtyExited,
 }
 
 fn main() {

--- a/crates/seance-app/src/window_state.rs
+++ b/crates/seance-app/src/window_state.rs
@@ -67,13 +67,12 @@ impl WindowState {
         self.request_redraw();
     }
 
-    /// Read pending PTY output. Returns `false` when the child has exited —
-    /// caller should tear the window down.
-    pub(crate) fn poll_pty(&mut self) -> bool {
-        if self.terminal.poll() {
-            self.content_dirty = true;
-        }
-        self.terminal.is_alive()
+    /// Feed PTY output into the VT and request a redraw. Called from the
+    /// `UserEvent::PtyData` handler; the read itself happens on the IO
+    /// thread spawned in `App::resumed`.
+    pub(crate) fn feed_pty(&mut self, data: &[u8]) {
+        self.terminal.feed(data);
+        self.mark_dirty();
     }
 
     /// Resize the surface and reflow the VT grid.

--- a/crates/seance-vt/Cargo.toml
+++ b/crates/seance-vt/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 description = "VT emulator wrapper, PTY, and selection for seance"
 
 [dependencies]
-libc.workspace = true
 libghostty-vt.workspace = true
 log.workspace = true
 png = "0.18"

--- a/crates/seance-vt/src/terminal.rs
+++ b/crates/seance-vt/src/terminal.rs
@@ -76,7 +76,9 @@ pub struct Terminal {
     /// per-row flags remain until the caller clears them.
     render_state: RenderState<'static>,
     response_buf: Rc<RefCell<Vec<u8>>>,
-    reader: Box<dyn Read + Send>,
+    /// `None` after [`Self::take_reader`]: the reader has been moved off
+    /// to a dedicated thread that does blocking PTY reads.
+    reader: Option<Box<dyn Read + Send>>,
     writer: RefCell<Box<dyn Write + Send>>,
     master: Box<dyn MasterPty + Send>,
     child: Box<dyn Child + Send + Sync>,
@@ -137,22 +139,13 @@ impl Terminal {
         let reader = pair.master.try_clone_reader().ok()?;
         let writer = pair.master.take_writer().ok()?;
 
-        // Non-blocking so poll() never blocks the event loop.
-        #[cfg(unix)]
-        if let Some(fd) = pair.master.as_raw_fd() {
-            unsafe {
-                let flags = libc::fcntl(fd, libc::F_GETFL);
-                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
-            }
-        }
-
         let render_state = RenderState::new().ok()?;
 
         Some(Self {
             vt,
             render_state,
             response_buf,
-            reader,
+            reader: Some(reader),
             writer: RefCell::new(writer),
             master: pair.master,
             child,
@@ -162,23 +155,28 @@ impl Terminal {
         })
     }
 
-    /// Read pending PTY output, feed the VT, flush device responses.
-    /// Returns true if new data arrived.
-    pub fn poll(&mut self) -> bool {
-        let mut buf = [0u8; READ_CHUNK];
-        let mut got_data = false;
-        while let Ok(n) = self.reader.read(&mut buf) {
-            if n == 0 {
-                break;
-            }
-            self.vt.vt_write(&buf[..n]);
-            got_data = true;
+    /// Move the PTY reader out of the terminal so a dedicated IO thread
+    /// can own the blocking `read()`. Returns `None` if a previous caller
+    /// already took it. After this, [`Self::feed`] is the only path that
+    /// drives PTY bytes into the VT.
+    pub fn take_reader(&mut self) -> Option<Box<dyn Read + Send>> {
+        self.reader.take()
+    }
+
+    /// Suggested chunk size for the IO thread reading PTY output.
+    pub const READ_CHUNK_SIZE: usize = READ_CHUNK;
+
+    /// Feed PTY output into the VT and flush any device responses the VT
+    /// produced (cursor reports, DA1, etc.) back to the shell. Replaces
+    /// the old `poll()` path; the read itself happens on the IO thread.
+    pub fn feed(&mut self, data: &[u8]) {
+        if !data.is_empty() {
+            self.vt.vt_write(data);
         }
         let responses = self.response_buf.take();
         if !responses.is_empty() {
             let _ = self.writer.borrow_mut().write_all(&responses);
         }
-        got_data
     }
 
     /// Seed the VT's cursor shape with a DECSCUSR sequence (steady


### PR DESCRIPTION
## Summary
Refactor the PTY reading architecture to eliminate the 250 Hz polling interval. PTY output is now read on a dedicated IO thread and forwarded to the UI via `EventLoopProxy`, while animation deadlines (cursor blink) drive the event loop's wake schedule instead of a fixed poll interval.

## Key Changes

- **New PTY reader thread** (`crates/seance-app/src/io.rs`): Spawns a dedicated thread that performs blocking reads on the PTY master and forwards chunks to the UI thread via `EventLoopProxy`. The thread exits gracefully on EOF or read errors, signaling `UserEvent::PtyExited`.

- **Event-driven PTY updates**: Replaced `WindowState::poll_pty()` with `feed_pty()`, which is called from the new `UserEvent::PtyData` handler. PTY output now wakes the event loop out-of-band instead of requiring periodic polling.

- **Deadline-scheduled animations**: Introduced `App::next_animation_deadline()` to compute the next wake time based on cursor blink state. The event loop now uses `ControlFlow::WaitUntil(deadline)` when animations are active and `ControlFlow::Wait` when idle, replacing the fixed `POLL_INTERVAL` wakeup.

- **Terminal API changes**: 
  - `Terminal::reader` is now `Option<Box<dyn Read + Send>>` to support moving the reader to the IO thread via `take_reader()`
  - Replaced `poll()` (which did blocking reads) with `feed()` (which processes pre-read data)
  - Removed non-blocking flag setup since the reader is no longer on the event loop thread

- **Renamed method**: `tick_blink()` → `step_blink()` with updated documentation clarifying it's called after deadline-scheduled wakes.

- **Removed dependency**: `libc` is no longer needed in `seance-vt` since non-blocking flag setup was removed.

## Implementation Details

The PTY reader thread uses `Terminal::READ_CHUNK_SIZE` for buffer allocation and handles `EINTR` by retrying. The `EventLoopProxy` is cloned and passed to the reader thread; if the proxy fails (event loop already exited), the thread exits silently. This design ensures the UI thread remains responsive to both PTY output and animation deadlines without busy-waiting.

https://claude.ai/code/session_01A3mWa7ZytMsQtx2vE7HLaU