### PR TITLE
feat(vt): make Terminal Send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 [[package]]
 name = "libghostty-vt"
 version = "0.1.1"
-source = "git+https://github.com/Uzaaft/libghostty-rs?rev=dfac6f3e#dfac6f3e8e7ff1567a7dead6639ef36c42e4f15a"
+source = "git+https://github.com/xkef/libghostty-rs?rev=02c0b67331589479cbcdee9dd7ed38c0c2ff6a7d#02c0b67331589479cbcdee9dd7ed38c0c2ff6a7d"
 dependencies = [
  "bitflags 2.11.0",
  "int-enum",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.1.1"
-source = "git+https://github.com/Uzaaft/libghostty-rs?rev=dfac6f3e#dfac6f3e8e7ff1567a7dead6639ef36c42e4f15a"
+source = "git+https://github.com/xkef/libghostty-rs?rev=02c0b67331589479cbcdee9dd7ed38c0c2ff6a7d#02c0b67331589479cbcdee9dd7ed38c0c2ff6a7d"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ collapsible_if = "warn"
 log = "0.4"
 env_logger = "0.11"
 libc = "0.2"
-libghostty-vt = { git = "https://github.com/Uzaaft/libghostty-rs", rev = "dfac6f3e", default-features = false, features = ["kitty-graphics", "png"] }
+libghostty-vt = { git = "https://github.com/xkef/libghostty-rs", rev = "02c0b67331589479cbcdee9dd7ed38c0c2ff6a7d", default-features = false, features = ["kitty-graphics", "png"] }
 insta = { version = "1", features = ["glob", "yaml"] }
 pretty_assertions = "1"
 rand_pcg = "0.3"

--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -84,7 +84,8 @@ impl App {
         }
         if ws.content_dirty {
             ws.content_dirty = false;
-            let mut source = LibGhosttyFrameSource::new(&mut ws.terminal);
+            let selection = ws.selection_range();
+            let mut source = LibGhosttyFrameSource::new(&mut ws.terminal, selection);
             // Cache the VT's DECSCUSR-tracked shape (if any) before the
             // renderer consumes the source — mode changes in neovim arrive
             // as PTY bytes that set `content_dirty`, so this branch runs

--- a/crates/seance-app/src/events.rs
+++ b/crates/seance-app/src/events.rs
@@ -76,7 +76,7 @@ impl App {
             }
             AppCommand::SelectAll => {
                 if let Some(ws) = self.ws_mut() {
-                    ws.terminal.select_all();
+                    ws.select_all();
                     ws.sync_selection_to_overlay();
                 }
             }
@@ -124,7 +124,7 @@ impl App {
             return;
         }
         let (col, row) = ws.renderer.pixel_to_grid(position.x, position.y);
-        ws.terminal.update_selection(col, row);
+        ws.update_selection(col, row);
         ws.sync_selection_to_overlay();
         ws.mark_dirty();
     }
@@ -156,9 +156,9 @@ fn handle_mouse_press(ws: &mut WindowState) {
         .pixel_to_grid(ws.mouse.cursor_pos.x, ws.mouse.cursor_pos.y);
     let clicks = ws.mouse.register_click(col, row);
     match clicks {
-        1 => ws.terminal.start_selection(col, row),
-        2 => ws.terminal.start_word_selection(col, row),
-        3 => ws.terminal.start_line_selection(row),
+        1 => ws.start_selection(col, row),
+        2 => ws.start_word_selection(col, row),
+        3 => ws.start_line_selection(row),
         _ => {}
     }
     ws.sync_selection_to_overlay();

--- a/crates/seance-app/src/window_state.rs
+++ b/crates/seance-app/src/window_state.rs
@@ -12,7 +12,7 @@ use winit::event::Modifiers;
 use winit::window::Window;
 
 use seance_render::{RenderInputs, TerminalRenderer};
-use seance_vt::{CursorShape as VtCursorShape, Terminal, TerminalModes};
+use seance_vt::{CursorShape as VtCursorShape, GridPos, Selection, Terminal, TerminalModes};
 
 use crate::mouse::MouseState;
 
@@ -26,6 +26,7 @@ pub(crate) struct WindowState {
     pub(crate) content_dirty: bool,
     pub(crate) occluded: bool,
     pub(crate) mouse: MouseState,
+    selection: Option<Selection>,
     pub(crate) blink_on: bool,
     pub(crate) last_blink_edge: Instant,
     // `None` until the VT has reported a shape via DECSCUSR; then the
@@ -52,6 +53,7 @@ impl WindowState {
             content_dirty: true,
             occluded: false,
             mouse: MouseState::default(),
+            selection: None,
             blink_on: true,
             last_blink_edge: Instant::now(),
             last_vt_cursor_shape: None,
@@ -95,20 +97,55 @@ impl WindowState {
     }
 
     pub(crate) fn has_selection(&self) -> bool {
-        self.terminal.has_selection()
+        self.selection.is_some()
     }
 
     pub(crate) fn clear_selection(&mut self) {
-        self.terminal.clear_selection();
+        self.selection = None;
         self.render_inputs.selection = None;
     }
 
+    pub(crate) fn selection_range(&self) -> Option<(GridPos, GridPos)> {
+        self.selection.as_ref().map(Selection::ordered_range)
+    }
+
     pub(crate) fn sync_selection_to_overlay(&mut self) {
-        self.render_inputs.selection = self.terminal.selection_range();
+        self.render_inputs.selection = self.selection_range();
+    }
+
+    pub(crate) fn start_selection(&mut self, col: u16, row: u16) {
+        self.selection = Some(Selection::new(GridPos { col, row }));
+    }
+
+    pub(crate) fn start_word_selection(&mut self, col: u16, row: u16) {
+        self.selection = Some(Selection::new_word(GridPos { col, row }));
+    }
+
+    pub(crate) fn start_line_selection(&mut self, row: u16) {
+        self.selection = Some(Selection::new_line(GridPos { col: 0, row }));
+    }
+
+    pub(crate) fn update_selection(&mut self, col: u16, row: u16) {
+        if let Some(selection) = &mut self.selection {
+            selection.update(GridPos { col, row });
+        }
+    }
+
+    pub(crate) fn select_all(&mut self) {
+        let (cols, rows) = self.renderer.grid_size();
+        let mut selection = Selection::new_line(GridPos { col: 0, row: 0 });
+        selection.update(GridPos {
+            col: cols.saturating_sub(1),
+            row: rows.saturating_sub(1),
+        });
+        self.selection = Some(selection);
     }
 
     pub(crate) fn copy_selection_to_clipboard(&mut self) {
-        let Some(text) = self.terminal.selection_text() else {
+        let Some(selection) = self.selection.as_ref() else {
+            return;
+        };
+        let Some(text) = self.terminal.selection_text(selection) else {
             return;
         };
         if text.is_empty() {
@@ -119,7 +156,7 @@ impl WindowState {
         }
     }
 
-    pub(crate) fn paste_from_clipboard(&self) {
+    pub(crate) fn paste_from_clipboard(&mut self) {
         let Ok(mut cb) = arboard::Clipboard::new() else {
             return;
         };

--- a/crates/seance-vt/src/frame_source.rs
+++ b/crates/seance-vt/src/frame_source.rs
@@ -19,11 +19,12 @@ use crate::terminal::Terminal;
 
 pub struct LibGhosttyFrameSource<'a> {
     term: &'a mut Terminal,
+    selection: Option<(GridPos, GridPos)>,
 }
 
 impl<'a> LibGhosttyFrameSource<'a> {
-    pub fn new(term: &'a mut Terminal) -> Self {
-        Self { term }
+    pub fn new(term: &'a mut Terminal, selection: Option<(GridPos, GridPos)>) -> Self {
+        Self { term, selection }
     }
 }
 
@@ -62,7 +63,7 @@ impl FrameSource for LibGhosttyFrameSource<'_> {
     }
 
     fn selection(&mut self) -> Option<(GridPos, GridPos)> {
-        self.term.selection_range()
+        self.selection
     }
 
     fn visit_cells(&mut self, visitor: &mut dyn CellVisitor) {

--- a/crates/seance-vt/src/lib.rs
+++ b/crates/seance-vt/src/lib.rs
@@ -21,5 +21,5 @@ pub use frame::{
 };
 pub use frame_source::LibGhosttyFrameSource;
 pub use modes::TerminalModes;
-pub use selection::GridPos;
-pub use terminal::Terminal;
+pub use selection::{GridPos, Selection, SelectionGranularity};
+pub use terminal::{Terminal, install_png_decoder_for_this_thread};

--- a/crates/seance-vt/src/terminal.rs
+++ b/crates/seance-vt/src/terminal.rs
@@ -1,9 +1,7 @@
-//! High-level terminal: VT emulator + PTY + selection.
+//! High-level terminal: VT emulator + PTY.
 
-use std::cell::RefCell;
 use std::io::{Read, Write};
-use std::rc::Rc;
-use std::sync::Once;
+use std::sync::{Arc, Mutex};
 
 use libghostty_vt::alloc::{Allocator, Bytes};
 use libghostty_vt::kitty::graphics::{self, DecodePng, DecodedImage};
@@ -57,17 +55,15 @@ impl DecodePng for PngDecoder {
     }
 }
 
-/// Install the PNG decoder. Safe to call repeatedly; only takes effect once.
+/// Install the PNG decoder for the current thread.
+///
 /// The decoder is thread-local inside libghostty-vt, so this must run on the
 /// thread that owns the terminal.
-fn install_png_decoder_once() {
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let _ = graphics::set_png_decoder(Some(PngDecoder));
-    });
+pub fn install_png_decoder_for_this_thread() {
+    let _ = graphics::set_png_decoder(Some(Box::new(PngDecoder)));
 }
 
-/// A terminal session: VT emulator, PTY, and text selection state.
+/// A terminal session: VT emulator and PTY.
 pub struct Terminal {
     vt: Box<VtTerminal<'static, 'static>>,
     /// Persistent render state. libghostty-vt's dirty tracking only
@@ -75,14 +71,13 @@ pub struct Terminal {
     /// `update(vt)` drains the VT's dirty set into the render state, and
     /// per-row flags remain until the caller clears them.
     render_state: RenderState<'static>,
-    response_buf: Rc<RefCell<Vec<u8>>>,
+    response_buf: Arc<Mutex<Vec<u8>>>,
     /// `None` after [`Self::take_reader`]: the reader has been moved off
     /// to a dedicated thread that does blocking PTY reads.
     reader: Option<Box<dyn Read + Send>>,
-    writer: RefCell<Box<dyn Write + Send>>,
+    writer: Box<dyn Write + Send>,
     master: Box<dyn MasterPty + Send>,
     child: Box<dyn Child + Send + Sync>,
-    selection: Option<Selection>,
     /// Per-cell pixel dimensions as last passed to `vt.resize()`. Needed
     /// to convert virtual-placement cell coordinates into pixel rects.
     cell_width_px: u32,
@@ -92,7 +87,7 @@ pub struct Terminal {
 impl Terminal {
     /// Spawn a new shell in a PTY.
     pub fn spawn(cols: u16, rows: u16, pixel_width: u16, pixel_height: u16) -> Option<Self> {
-        install_png_decoder_once();
+        install_png_decoder_for_this_thread();
 
         let mut vt = Box::new(
             VtTerminal::new(TerminalOptions {
@@ -118,10 +113,14 @@ impl Terminal {
         let (cell_w, cell_h) = cell_px(cols, rows, pixel_width, pixel_height);
         vt.resize(cols, rows, cell_w, cell_h).ok()?;
 
-        let response_buf = Rc::new(RefCell::new(Vec::new()));
-        let buf = Rc::clone(&response_buf);
-        vt.on_pty_write(move |_, data| buf.borrow_mut().extend_from_slice(data))
-            .ok()?;
+        let response_buf = Arc::new(Mutex::new(Vec::new()));
+        let buf = Arc::clone(&response_buf);
+        vt.on_pty_write(move |_, data| {
+            buf.lock()
+                .expect("terminal response buffer mutex poisoned")
+                .extend_from_slice(data);
+        })
+        .ok()?;
 
         let pair = native_pty_system()
             .openpty(PtySize {
@@ -146,10 +145,9 @@ impl Terminal {
             render_state,
             response_buf,
             reader: Some(reader),
-            writer: RefCell::new(writer),
+            writer,
             master: pair.master,
             child,
-            selection: None,
             cell_width_px: cell_w,
             cell_height_px: cell_h,
         })
@@ -173,9 +171,15 @@ impl Terminal {
         if !data.is_empty() {
             self.vt.vt_write(data);
         }
-        let responses = self.response_buf.take();
+        let responses = {
+            let mut buf = self
+                .response_buf
+                .lock()
+                .expect("terminal response buffer mutex poisoned");
+            std::mem::take(&mut *buf)
+        };
         if !responses.is_empty() {
-            let _ = self.writer.borrow_mut().write_all(&responses);
+            let _ = self.writer.write_all(&responses);
         }
     }
 
@@ -194,8 +198,8 @@ impl Terminal {
     }
 
     /// Write raw bytes to the PTY (keyboard input, paste, etc.).
-    pub fn write(&self, data: &[u8]) {
-        let _ = self.writer.borrow_mut().write_all(data);
+    pub fn write(&mut self, data: &[u8]) {
+        let _ = self.writer.write_all(data);
     }
 
     pub fn is_alive(&mut self) -> bool {
@@ -244,53 +248,8 @@ impl Terminal {
         }
     }
 
-    // -- Selection ----------------------------------------------------
-
-    pub fn start_selection(&mut self, col: u16, row: u16) {
-        self.selection = Some(Selection::new(GridPos { col, row }));
-    }
-
-    pub fn start_word_selection(&mut self, col: u16, row: u16) {
-        self.selection = Some(Selection::new_word(GridPos { col, row }));
-    }
-
-    pub fn start_line_selection(&mut self, row: u16) {
-        self.selection = Some(Selection::new_line(GridPos { col: 0, row }));
-    }
-
-    pub fn update_selection(&mut self, col: u16, row: u16) {
-        if let Some(sel) = &mut self.selection {
-            sel.update(GridPos { col, row });
-        }
-    }
-
-    pub fn has_selection(&self) -> bool {
-        self.selection.is_some()
-    }
-
-    pub fn selection_range(&self) -> Option<(GridPos, GridPos)> {
-        self.selection.as_ref().map(Selection::ordered_range)
-    }
-
-    pub fn clear_selection(&mut self) {
-        self.selection = None;
-    }
-
-    /// Select the entire visible grid as a line selection.
-    pub fn select_all(&mut self) {
-        let cols = self.vt.cols().unwrap_or(80);
-        let rows = self.vt.rows().unwrap_or(24);
-        let mut sel = Selection::new_line(GridPos { col: 0, row: 0 });
-        sel.update(GridPos {
-            col: cols.saturating_sub(1),
-            row: rows.saturating_sub(1),
-        });
-        self.selection = Some(sel);
-    }
-
     /// Extract the selected text from the live VT grid.
-    pub fn selection_text(&mut self) -> Option<String> {
-        let sel = self.selection.as_ref()?;
+    pub fn selection_text(&mut self, sel: &Selection) -> Option<String> {
         let (start, end) = sel.ordered_range();
         let granularity = sel.granularity();
         let cols = self.vt.cols().unwrap_or(80);
@@ -437,5 +396,34 @@ fn column_range(
             let ce = if row_idx == end.row { end.col } else { last };
             (cs, ce)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libghostty_vt::RenderState;
+    use libghostty_vt::Terminal as VtTerminal;
+
+    use super::*;
+
+    #[test]
+    fn terminal_is_send() {
+        fn assert_send<T: Send>() {}
+
+        assert_send::<Terminal>();
+        assert_send::<VtTerminal<'static, 'static>>();
+        assert_send::<RenderState<'static>>();
+    }
+
+    #[test]
+    fn terminal_can_be_constructed_on_worker_thread() {
+        std::thread::spawn(|| {
+            install_png_decoder_for_this_thread();
+            let mut terminal =
+                Terminal::spawn(24, 5, 240, 80).expect("worker thread should construct terminal");
+            terminal.feed(b"\x1b[c");
+        })
+        .join()
+        .expect("worker thread should not panic");
     }
 }

--- a/crates/seance-vt/src/test_support.rs
+++ b/crates/seance-vt/src/test_support.rs
@@ -4,8 +4,7 @@
 //! `seance-render-test`. Do not widen without coordinating with the
 //! harness crate.
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use libghostty_vt::terminal::Mode;
 use libghostty_vt::{Terminal as VtTerminal, TerminalOptions};
@@ -29,7 +28,7 @@ const MAX_SCROLLBACK: usize = 10_000;
 /// the production `LibGhosttyFrameSource`.
 pub struct HeadlessTerminal {
     vt: Box<VtTerminal<'static, 'static>>,
-    responses: Rc<RefCell<Vec<u8>>>,
+    responses: Arc<Mutex<Vec<u8>>>,
 }
 
 impl HeadlessTerminal {
@@ -48,10 +47,14 @@ impl HeadlessTerminal {
         // virtual-placement rendering is out of scope for the harness.
         vt.resize(cols, rows, 0, 0).ok()?;
 
-        let responses = Rc::new(RefCell::new(Vec::new()));
-        let sink = Rc::clone(&responses);
-        vt.on_pty_write(move |_, data| sink.borrow_mut().extend_from_slice(data))
-            .ok()?;
+        let responses = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&responses);
+        vt.on_pty_write(move |_, data| {
+            sink.lock()
+                .expect("headless terminal response buffer mutex poisoned")
+                .extend_from_slice(data);
+        })
+        .ok()?;
 
         Some(Self { vt, responses })
     }
@@ -64,7 +67,11 @@ impl HeadlessTerminal {
     /// Drain any VT-originated response bytes accumulated since the
     /// last call.
     pub fn take_responses(&self) -> Vec<u8> {
-        self.responses.take()
+        let mut responses = self
+            .responses
+            .lock()
+            .expect("headless terminal response buffer mutex poisoned");
+        std::mem::take(&mut *responses)
     }
 
     pub fn cols(&self) -> u16 {

--- a/docs/threading.md
+++ b/docs/threading.md
@@ -369,25 +369,24 @@ Child-exit ordering: the IO thread observes `read() == 0` (EOF) and sends
 event-loop iteration; if the user has already closed the window, the event is
 dropped silently.
 
-### Send/Sync audit (current blocker, [#166])
+### Send/Sync audit ([#166])
 
-`seance-vt::Terminal` is `!Send` today
-(`crates/seance-vt/src/terminal.rs:78,82`):
+[#166] makes `seance-vt::Terminal` movable to the future IO thread:
 
-- `response_buf: Rc<RefCell<Vec<u8>>>` — `Rc` is `!Send`. Captured by the
-  `vt.on_pty_write` callback.
-- `writer: RefCell<Box<dyn Write + Send>>` — `RefCell` is `!Sync`; fine for
-  single-owner move, but only if we drop the `&self`-takes-lock pattern.
+- `response_buf` is `Arc<Mutex<Vec<u8>>>`, so the `vt.on_pty_write` callback
+  can satisfy libghostty-vt's `Send` callback bound.
+- `writer` is a plain `Box<dyn Write + Send>`, and `Terminal::write` takes
+  `&mut self`.
+- selection state is UI-owned; `Terminal::selection_text(&Selection)` reads the
+  live VT grid for copy operations.
+- `libghostty-vt` is pinned to the `xkef/libghostty-rs` fork revision that adds
+  static-lifetime `Send` for `Terminal` and `RenderState` without adding
+  `Sync`.
 
-The PNG decoder install (`terminal.rs:62-67`) is thread-local inside
-libghostty-vt, so whichever thread owns the VT must be the one to call
-`set_png_decoder`. Today that's the UI thread; under v1 it must move to the IO
-thread spawn callsite.
-
-[#166] is the prerequisite: rewrite `Terminal` so an `assert_send::<Terminal>()`
-test compile-passes, and move the PNG decoder install to a per-thread callable.
-The upstream `libghostty-vt::Terminal` `Send` story also gets audited there — if
-`Uzaaft/libghostty-rs` lacks `unsafe impl Send`, we propose a PR.
+The PNG decoder install is exposed as
+`install_png_decoder_for_this_thread()`. `Terminal::spawn` still calls it for
+the current UI-owned terminal; the IO-thread spawn in [#167] must call the same
+function on the owning IO thread.
 
 ---
 
@@ -430,7 +429,7 @@ layout off-thread, ship the result back via a channel, render on the foreground.
 | --- | ----------------------------------------------- | ------------------------------------------------------------------------------ |
 | 1   | `Mutex` vs `RwLock` vs `parking_lot::FairMutex` | `parking_lot::FairMutex` — Alacritty pattern, avoids reader starvation         |
 | 2   | Bounded vs unbounded `mpsc`                     | `Write` unbounded (or 4096-cap); coalesceable types use slots                  |
-| 3   | Is `libghostty-vt::Terminal` `Send`?            | audit deferred to [#166]; PR upstream if necessary                             |
+| 3   | Is `libghostty-vt::Terminal` `Send`?            | yes via `xkef/libghostty-rs` fork rev used by [#166]; still `!Sync`            |
 | 4   | PNG decoder install location                    | move to IO-thread spawn (`install_png_decoder_for_this_thread()`)              |
 | 5   | Selection state ownership                       | hoist to UI side; `selection_text(&Selection)` reads under lock                |
 | 6   | `crossbeam::channel` or `std::sync::mpsc`?      | `std::sync::mpsc`; we don't use `select!` and dependency surface stays smaller |


### PR DESCRIPTION
## Summary

- Pin `libghostty-vt` to the `xkef/libghostty-rs` fork revision that makes static-lifetime `Terminal` and `RenderState` `Send` without adding `Sync`.
- Replace `seance-vt` response buffering with `Arc<Mutex<Vec<u8>>>`, make `Terminal::write` require `&mut self`, and expose `install_png_decoder_for_this_thread()`.
- Move selection state out of `Terminal` and into `WindowState`, while keeping VT-backed text extraction via `selection_text(&Selection)`.
- Update threading docs for the resolved #166 Send/PNG-decoder state.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Notes

The `xkef/libghostty-rs` fork branch used here is `seance-terminal-send` at `02c0b67331589479cbcdee9dd7ed38c0c2ff6a7d`. No upstream PRs or comments were created.