### PR TITLE
fix(vt): bump kitty image storage cap to 320 MB

### DIFF
--- a/crates/seance-vt/src/terminal.rs
+++ b/crates/seance-vt/src/terminal.rs
@@ -21,8 +21,11 @@ const READ_CHUNK: usize = 4096;
 const MAX_SCROLLBACK: usize = 10_000;
 
 /// Kitty image storage cap per terminal. Non-zero enables the protocol;
-/// ghostty evicts oldest images when we would exceed this limit.
-const KITTY_IMAGE_STORAGE_LIMIT_BYTES: u64 = 64 * 1024 * 1024;
+/// ghostty evicts oldest images (LRU) when we would exceed this limit.
+/// Matches ghostty's upstream default (`image-storage-limit`); a 4K RGBA
+/// frame is ~33 MB, so a smaller cap thrashes on presenterm decks that
+/// re-transmit the same image with a fresh id on every slide visit.
+const KITTY_IMAGE_STORAGE_LIMIT_BYTES: u64 = 320 * 1000 * 1000;
 
 /// PNG decoder for the Kitty graphics protocol.
 ///


### PR DESCRIPTION
A 4K RGBA frame decodes to ~33 MB; the previous 64 MiB cap thrashed
on presenterm decks that re-transmit the same image with a fresh id
on every slide visit. With only one of those images fitting at a
time, the older image was evicted on each new transmit, leaving
presenterm's unicode-placeholder cells pointing at an image id no
longer in storage. walk_virtual_placements then silently skipped
the placement (graphics.image(id) returns None), so the image
vanished and presenterm's spinner persisted.

Bump to 320 * 1000 * 1000, matching ghostty's upstream
image-storage-limit default. Holds ~9 frames of that size, which
covers the common revisit case without disabling LRU for genuinely
heavy decks.

No tracked issue.