### PR TITLE
feat(input): forward mouse button events to pty as vt mouse reports

### DIFF
--- a/crates/seance-app/src/events.rs
+++ b/crates/seance-app/src/events.rs
@@ -6,7 +6,7 @@ use winit::dpi::PhysicalPosition;
 use winit::event::{ElementState, MouseButton};
 use winit::event_loop::ActiveEventLoop;
 
-use seance_input::VtInput;
+use seance_input::{MouseAction, MouseEventInput, VtInput};
 
 use crate::app::App;
 use crate::command::AppCommand;
@@ -129,6 +129,28 @@ impl App {
             return;
         };
         surface.mouse.cursor_pos = position;
+
+        let modes = surface.terminal_modes();
+        let shift_held = surface.modifiers.state().shift_key();
+        // Forward motion to the PTY when an app has opted into motion-bearing
+        // tracking modes (DECSET 1002 button-event or 1003 any-event), unless
+        // the user is holding Shift to force local selection. The encoder
+        // itself filters X10/Normal and the no-button-held case under 1002.
+        if modes.mouse_tracking.reports_motion() && !shift_held {
+            let input = MouseEventInput {
+                action: MouseAction::Motion,
+                button: None,
+                position_px: clamp_position(position),
+                any_button_pressed: surface.mouse.is_down,
+                mods: surface.modifiers,
+                size: surface.renderer.mouse_size(),
+            };
+            if let Some(data) = self.input.encode_mouse_event(input, modes) {
+                surface.write_to_pty(Bytes::from(data));
+            }
+            return;
+        }
+
         if !surface.mouse.is_down {
             return;
         }
@@ -139,12 +161,46 @@ impl App {
     }
 
     pub(crate) fn on_mouse_input(&mut self, state: ElementState, button: MouseButton) {
-        if button != MouseButton::Left {
-            return;
-        }
         let Some(surface) = self.surface.as_mut() else {
             return;
         };
+
+        let modes = surface.terminal_modes();
+        let shift_held = surface.modifiers.state().shift_key();
+        // Tracking active and Shift not held: forward to the PTY and skip
+        // the local-selection path entirely. Shift+click/drag preserves
+        // local selection so users can still copy text inside mouse-aware
+        // apps (xterm/Ghostty convention).
+        if modes.mouse_tracking.is_enabled() && !shift_held {
+            let action = match state {
+                ElementState::Pressed => MouseAction::Press,
+                ElementState::Released => MouseAction::Release,
+            };
+            // Update `is_down` BEFORE encoding so that any-button-pressed
+            // reflects the post-event state when reporting under DECSET
+            // 1002 motion (xterm reports drag bytes carrying the held
+            // button, and the very first motion after press needs the
+            // bit set).
+            surface.mouse.is_down = state == ElementState::Pressed;
+            let input = MouseEventInput {
+                action,
+                button: Some(button),
+                position_px: clamp_position(surface.mouse.cursor_pos),
+                any_button_pressed: surface.mouse.is_down,
+                mods: surface.modifiers,
+                size: surface.renderer.mouse_size(),
+            };
+            if let Some(data) = self.input.encode_mouse_event(input, modes) {
+                surface.write_to_pty(Bytes::from(data));
+            }
+            return;
+        }
+
+        // Tracking off (or Shift held): legacy local-selection path.
+        // Right/middle remain unbound locally — match the old behavior.
+        if button != MouseButton::Left {
+            return;
+        }
         match state {
             ElementState::Pressed => handle_mouse_press(surface),
             ElementState::Released => {
@@ -153,6 +209,10 @@ impl App {
             }
         }
     }
+}
+
+fn clamp_position(p: PhysicalPosition<f64>) -> (f32, f32) {
+    (p.x.max(0.0) as f32, p.y.max(0.0) as f32)
 }
 
 fn handle_mouse_press(surface: &mut SurfaceState) {

--- a/crates/seance-input/src/lib.rs
+++ b/crates/seance-input/src/lib.rs
@@ -7,8 +7,8 @@
 mod keymap;
 
 use libghostty_vt::{key, mouse};
-use seance_protocol::TerminalModes;
-use winit::event::{ElementState, KeyEvent, Modifiers};
+use seance_protocol::{MouseSize, MouseTracking, TerminalModes};
+use winit::event::{ElementState, KeyEvent, Modifiers, MouseButton};
 use winit::keyboard::{Key, PhysicalKey};
 #[cfg(target_os = "macos")]
 use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
@@ -50,6 +50,66 @@ impl OptionAsAlt {
             Self::Right => key::OptionAsAlt::Right,
             Self::Both => key::OptionAsAlt::True,
         }
+    }
+}
+
+/// Press / Release / Motion classification for a mouse event the app
+/// wants forwarded to the PTY. Mirrors libghostty-vt's `mouse::Action`
+/// without forcing callers to import the libghostty type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseAction {
+    Press,
+    Release,
+    Motion,
+}
+
+/// Inputs to `InputHandler::encode_mouse_event`. Pure-data record so
+/// callers don't have to talk to libghostty-vt directly.
+#[derive(Debug, Clone, Copy)]
+pub struct MouseEventInput {
+    pub action: MouseAction,
+    /// `None` is permitted only for `Action::Motion` under any-event
+    /// tracking, where there is no button to report.
+    pub button: Option<MouseButton>,
+    /// Surface-space pixel coordinates of the cursor. The encoder
+    /// converts these to cell coordinates internally using `size`.
+    pub position_px: (f32, f32),
+    /// Whether at least one mouse button is currently held. Used by
+    /// the encoder to distinguish motion-with-drag from pure motion
+    /// under DECSET 1002.
+    pub any_button_pressed: bool,
+    pub mods: Modifiers,
+    pub size: MouseSize,
+}
+
+fn tracking_mode_to_libghostty(t: MouseTracking) -> mouse::TrackingMode {
+    match t {
+        MouseTracking::None => mouse::TrackingMode::None,
+        MouseTracking::X10 => mouse::TrackingMode::X10,
+        MouseTracking::Normal => mouse::TrackingMode::Normal,
+        MouseTracking::Button => mouse::TrackingMode::Button,
+        MouseTracking::Any => mouse::TrackingMode::Any,
+    }
+}
+
+fn mouse_action_to_libghostty(a: MouseAction) -> mouse::Action {
+    match a {
+        MouseAction::Press => mouse::Action::Press,
+        MouseAction::Release => mouse::Action::Release,
+        MouseAction::Motion => mouse::Action::Motion,
+    }
+}
+
+fn map_mouse_button(button: MouseButton) -> Option<mouse::Button> {
+    match button {
+        MouseButton::Left => Some(mouse::Button::Left),
+        MouseButton::Right => Some(mouse::Button::Right),
+        MouseButton::Middle => Some(mouse::Button::Middle),
+        // winit "Back"/"Forward" are the side buttons; xterm conventionally
+        // assigns them as buttons 8 and 9.
+        MouseButton::Back => Some(mouse::Button::Eight),
+        MouseButton::Forward => Some(mouse::Button::Nine),
+        MouseButton::Other(_) => Some(mouse::Button::Unknown),
     }
 }
 
@@ -108,9 +168,11 @@ impl InputHandler {
     /// `None` when mouse tracking is off (caller should scroll the
     /// viewport locally instead).
     pub fn encode_mouse_wheel(&mut self, lines: i32, modes: TerminalModes) -> Option<Vec<u8>> {
-        if !modes.mouse_tracking {
+        if !modes.mouse_tracking.is_enabled() {
             return None;
         }
+        // Wheel encodes as buttons 4/5 in all xterm tracking modes; the
+        // sub-mode does not gate it.
         self.mouse_encoder
             .set_tracking_mode(mouse::TrackingMode::Normal);
         self.mouse_encoder.set_format(if modes.mouse_format_sgr {
@@ -133,6 +195,65 @@ impl InputHandler {
                 .set_position(mouse::Position { x: 0.0, y: 0.0 });
             self.mouse_encoder.encode_to_vec(&event, &mut out).ok()?;
         }
+        if out.is_empty() { None } else { Some(out) }
+    }
+
+    /// Encode a mouse button or motion event as VT mouse sequences. Returns
+    /// `None` when mouse tracking is off, or when the event isn't reportable
+    /// under the active sub-mode (motion under X10/Normal, motion without a
+    /// button held under DECSET 1002).
+    pub fn encode_mouse_event(
+        &mut self,
+        input: MouseEventInput,
+        modes: TerminalModes,
+    ) -> Option<Vec<u8>> {
+        if !modes.mouse_tracking.is_enabled() {
+            return None;
+        }
+        if input.action == MouseAction::Motion {
+            // X10 and Normal never report motion. Button-event reports
+            // motion only while at least one button is held. Any-event
+            // always reports motion.
+            if !modes.mouse_tracking.reports_motion() {
+                return None;
+            }
+            if !modes.mouse_tracking.reports_motion_without_button() && !input.any_button_pressed {
+                return None;
+            }
+        }
+
+        self.mouse_encoder
+            .set_tracking_mode(tracking_mode_to_libghostty(modes.mouse_tracking));
+        self.mouse_encoder.set_format(if modes.mouse_format_sgr {
+            mouse::Format::Sgr
+        } else {
+            mouse::Format::X10
+        });
+        self.mouse_encoder.set_size(mouse::EncoderSize {
+            screen_width: input.size.screen_width,
+            screen_height: input.size.screen_height,
+            cell_width: input.size.cell_width.max(1),
+            cell_height: input.size.cell_height.max(1),
+            padding_top: input.size.padding_top,
+            padding_bottom: input.size.padding_bottom,
+            padding_left: input.size.padding_left,
+            padding_right: input.size.padding_right,
+        });
+        self.mouse_encoder
+            .set_any_button_pressed(input.any_button_pressed);
+
+        let mut event = mouse::Event::new().ok()?;
+        event
+            .set_action(mouse_action_to_libghostty(input.action))
+            .set_button(input.button.and_then(map_mouse_button))
+            .set_mods(keymap::map_mods(&input.mods))
+            .set_position(mouse::Position {
+                x: input.position_px.0,
+                y: input.position_px.1,
+            });
+
+        let mut out = Vec::new();
+        self.mouse_encoder.encode_to_vec(&event, &mut out).ok()?;
         if out.is_empty() { None } else { Some(out) }
     }
 
@@ -184,5 +305,149 @@ impl InputHandler {
         }
 
         buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn size() -> MouseSize {
+        MouseSize {
+            screen_width: 800,
+            screen_height: 600,
+            cell_width: 10,
+            cell_height: 20,
+            padding_top: 0,
+            padding_bottom: 0,
+            padding_left: 0,
+            padding_right: 0,
+        }
+    }
+
+    fn modes(tracking: MouseTracking, sgr: bool) -> TerminalModes {
+        TerminalModes {
+            cursor_keys: false,
+            mouse_tracking: tracking,
+            mouse_format_sgr: sgr,
+            bracketed_paste: false,
+        }
+    }
+
+    fn input(
+        action: MouseAction,
+        button: Option<MouseButton>,
+        any_pressed: bool,
+    ) -> MouseEventInput {
+        MouseEventInput {
+            action,
+            button,
+            position_px: (0.0, 0.0),
+            any_button_pressed: any_pressed,
+            mods: Modifiers::default(),
+            size: size(),
+        }
+    }
+
+    #[test]
+    fn tracking_disabled_returns_none() {
+        let mut h = InputHandler::new();
+        let out = h.encode_mouse_event(
+            input(MouseAction::Press, Some(MouseButton::Left), true),
+            modes(MouseTracking::None, true),
+        );
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn left_press_under_sgr_emits_sgr_csi() {
+        let mut h = InputHandler::new();
+        let out = h
+            .encode_mouse_event(
+                input(MouseAction::Press, Some(MouseButton::Left), true),
+                modes(MouseTracking::Normal, true),
+            )
+            .expect("press should encode under Normal+SGR");
+        // SGR mouse press starts ESC [ < and ends with M.
+        assert_eq!(&out[..3], b"\x1b[<");
+        assert_eq!(*out.last().unwrap(), b'M');
+    }
+
+    #[test]
+    fn left_release_under_sgr_emits_lowercase_m() {
+        let mut h = InputHandler::new();
+        let out = h
+            .encode_mouse_event(
+                input(MouseAction::Release, Some(MouseButton::Left), false),
+                modes(MouseTracking::Normal, true),
+            )
+            .expect("release should encode under Normal+SGR");
+        assert_eq!(&out[..3], b"\x1b[<");
+        assert_eq!(*out.last().unwrap(), b'm');
+    }
+
+    #[test]
+    fn motion_under_normal_returns_none() {
+        let mut h = InputHandler::new();
+        let out = h.encode_mouse_event(
+            input(MouseAction::Motion, None, true),
+            modes(MouseTracking::Normal, true),
+        );
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn motion_under_button_without_press_returns_none() {
+        let mut h = InputHandler::new();
+        let out = h.encode_mouse_event(
+            input(MouseAction::Motion, None, false),
+            modes(MouseTracking::Button, true),
+        );
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn motion_under_button_with_press_encodes() {
+        let mut h = InputHandler::new();
+        let out = h.encode_mouse_event(
+            input(MouseAction::Motion, Some(MouseButton::Left), true),
+            modes(MouseTracking::Button, true),
+        );
+        assert!(out.is_some());
+    }
+
+    #[test]
+    fn motion_under_any_without_press_encodes() {
+        let mut h = InputHandler::new();
+        let out = h.encode_mouse_event(
+            input(MouseAction::Motion, None, false),
+            modes(MouseTracking::Any, true),
+        );
+        assert!(out.is_some());
+    }
+
+    #[test]
+    fn wheel_disabled_when_tracking_none() {
+        let mut h = InputHandler::new();
+        assert!(
+            h.encode_mouse_wheel(1, modes(MouseTracking::None, true))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn wheel_enabled_under_any_tracking_mode() {
+        let mut h = InputHandler::new();
+        for t in [
+            MouseTracking::X10,
+            MouseTracking::Normal,
+            MouseTracking::Button,
+            MouseTracking::Any,
+        ] {
+            assert!(
+                h.encode_mouse_wheel(1, modes(t, true)).is_some(),
+                "wheel should encode under {t:?}",
+            );
+        }
     }
 }

--- a/crates/seance-protocol/src/lib.rs
+++ b/crates/seance-protocol/src/lib.rs
@@ -216,9 +216,45 @@ impl Selection {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TerminalModes {
     pub cursor_keys: bool,
-    pub mouse_tracking: bool,
+    pub mouse_tracking: MouseTracking,
     pub mouse_format_sgr: bool,
     pub bracketed_paste: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MouseTracking {
+    #[default]
+    None,
+    X10,
+    Normal,
+    Button,
+    Any,
+}
+
+impl MouseTracking {
+    pub fn is_enabled(self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    pub fn reports_motion(self) -> bool {
+        matches!(self, Self::Button | Self::Any)
+    }
+
+    pub fn reports_motion_without_button(self) -> bool {
+        matches!(self, Self::Any)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MouseSize {
+    pub screen_width: u32,
+    pub screen_height: u32,
+    pub cell_width: u32,
+    pub cell_height: u32,
+    pub padding_top: u32,
+    pub padding_bottom: u32,
+    pub padding_left: u32,
+    pub padding_right: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use seance_config::Theme;
 use seance_frame::FrameSource;
-use seance_protocol::{GridPos, ImageCacheEvent};
+use seance_protocol::{GridPos, ImageCacheEvent, MouseSize};
 use winit::window::Window;
 
 pub use crate::gpu::uniforms::CursorShape;
@@ -118,6 +118,27 @@ impl TerminalRenderer {
         let col = ((x as f32 - pad[0]) / self.cell_size[0]).max(0.0) as u16;
         let row = ((y as f32 - pad[1]) / self.cell_size[1]).max(0.0) as u16;
         (col, row)
+    }
+
+    /// Pixel-space geometry the libghostty-vt mouse encoder needs to
+    /// translate surface-space cursor positions into VT cell coordinates.
+    /// `grid_padding` layout matches `pixel_to_grid` above:
+    /// `[left, top, right, bottom]`.
+    pub fn mouse_size(&self) -> MouseSize {
+        let pad = self
+            .cell_builder
+            .last_frame()
+            .map_or([0.0; 4], |fi| fi.grid_padding);
+        MouseSize {
+            screen_width: self.surface_width,
+            screen_height: self.surface_height,
+            cell_width: (self.cell_size[0].max(1.0)) as u32,
+            cell_height: (self.cell_size[1].max(1.0)) as u32,
+            padding_left: pad[0].max(0.0) as u32,
+            padding_top: pad[1].max(0.0) as u32,
+            padding_right: pad[2].max(0.0) as u32,
+            padding_bottom: pad[3].max(0.0) as u32,
+        }
     }
 
     pub fn apply_image_cache_event(&mut self, event: &ImageCacheEvent) {

--- a/crates/seance-vt/src/modes.rs
+++ b/crates/seance-vt/src/modes.rs
@@ -1,1 +1,1 @@
-pub use seance_protocol::TerminalModes;
+pub use seance_protocol::{MouseTracking, TerminalModes};

--- a/crates/seance-vt/src/snapshot_extraction.rs
+++ b/crates/seance-vt/src/snapshot_extraction.rs
@@ -12,13 +12,28 @@ use crate::kitty_graphics::{extract_kitty_graphics, is_placeholder_text};
 use crate::modes::TerminalModes;
 use crate::selection::GridPos;
 use crate::snapshot::VtSnapshot;
+use seance_protocol::MouseTracking;
 
 /// Copy live libghostty mode flags into séance-owned input state.
 pub(crate) fn terminal_modes(vt: &VtTerminal<'static, 'static>) -> TerminalModes {
     let mode = |m| vt.mode(m).unwrap_or(false);
+    // Highest-precedence enabled mode wins. Apps typically only set
+    // one at a time, but xterm semantics say the most permissive
+    // tracking mode supersedes the others when more than one is on.
+    let mouse_tracking = if mode(Mode::ANY_MOUSE) {
+        MouseTracking::Any
+    } else if mode(Mode::BUTTON_MOUSE) {
+        MouseTracking::Button
+    } else if mode(Mode::NORMAL_MOUSE) {
+        MouseTracking::Normal
+    } else if mode(Mode::X10_MOUSE) {
+        MouseTracking::X10
+    } else {
+        MouseTracking::None
+    };
     TerminalModes {
         cursor_keys: mode(Mode::DECCKM),
-        mouse_tracking: vt.is_mouse_tracking().unwrap_or(false),
+        mouse_tracking,
         mouse_format_sgr: mode(Mode::SGR_MOUSE),
         bracketed_paste: mode(Mode::BRACKETED_PASTE),
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ Epic index:
 ┌─ input ──────────────────────────────────────────────────────────────┐
 │ winit event loop → seance-input                                      │
 │   key: KeyboardEvent → libghostty-vt key encoder → bytes             │
-│   mouse: wheel/click → SGR 1006 encoding or ScrollLines              │
+│   mouse: wheel/click/drag → SGR 1006 / X10 encoding or ScrollLines   │
 │ UI sends mux PaneInput/ResizePane/ScrollLines                        │
 │ Local mux forwards to VT Actor, which writes PTY ─────────▶ shell    │
 └──────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
Mouse button presses, releases, and motion are now encoded as VT
mouse-tracking sequences and forwarded to the active pane's PTY.
htop column-sort, vim mouse, tmux mouse, and mc clicks now reach the
shell instead of being absorbed by the local text-selection path.

The libghostty-vt mouse encoder was already wired for wheel events;
the click/drag half just had no caller. This adds the caller and the
mode-state plumbing it needs.

`TerminalModes::mouse_tracking` becomes a `MouseTracking` enum
(`None`/`X10`/`Normal`/`Button`/`Any`) so the encoder can pick the
right libghostty `TrackingMode`. `seance-vt::snapshot_extraction`
populates it by querying `Mode::ANY_MOUSE` / `BUTTON_MOUSE` /
`NORMAL_MOUSE` / `X10_MOUSE` in precedence order, replacing the
collapsed `is_mouse_tracking()` bool.

`InputHandler::encode_mouse_event` is the new entrypoint. It honors
the tracking sub-mode (drops motion under X10/Normal, drops motion
without a held button under DECSET 1002), respects DECSET 1006 for
SGR vs X10 byte format, and feeds the encoder pixel geometry via
`Renderer::mouse_size()` so it can grid-convert internally.

`on_mouse_input` and `on_cursor_moved` route through the new encoder
when the active app has tracking enabled. Holding Shift bypasses the
PTY path and falls through to local selection, mirroring xterm and
Ghostty so users can still copy text from inside mouse-aware apps.

Closes #208