### PR TITLE
fix: rapid ArrowUp runs wrong history item

### DIFF
--- a/crates/seance-input/src/lib.rs
+++ b/crates/seance-input/src/lib.rs
@@ -280,8 +280,8 @@ impl InputHandler {
             .set_key(gk)
             .set_action(keymap::map_action(event.state))
             .set_mods(keymap::map_mods(modifiers));
-        if let Some(text) = &event.text {
-            key_event.set_utf8(Some(text.as_str()));
+        if let Some(text) = event.text.as_deref().filter(|t| is_safe_encoder_text(t)) {
+            key_event.set_utf8(Some(text));
         }
 
         let mut buf = Vec::new();
@@ -306,6 +306,20 @@ impl InputHandler {
 
         buf
     }
+}
+
+// `libghostty-vt::Event::set_utf8` requires the unmodified character before
+// any Ctrl/Meta transformations and explicitly forbids C0 controls
+// (U+0000-U+001F, U+007F) and macOS PUA function-key codes (U+F700-U+F8FF).
+// winit puts those codepoints in `event.text` for keys like Enter (`\r`),
+// Tab (`\t`), Backspace, and the macOS arrow / function keys — passing
+// them through leaves the encoder in an undefined state. Drop the text on
+// a forbidden codepoint and let the encoder fall back to the logical-key
+// path, which produces the documented VT sequence.
+fn is_safe_encoder_text(text: &str) -> bool {
+    !text
+        .chars()
+        .any(|c| c <= '\u{001F}' || c == '\u{007F}' || ('\u{F700}'..='\u{F8FF}').contains(&c))
 }
 
 #[cfg(test)]
@@ -449,5 +463,38 @@ mod tests {
                 "wheel should encode under {t:?}",
             );
         }
+    }
+
+    #[test]
+    fn safe_text_filter_rejects_libghostty_forbidden_codepoints() {
+        for c in ['\r', '\t', '\u{0008}', '\u{001B}', '\u{0000}', '\u{001F}'] {
+            let s = c.to_string();
+            assert!(
+                !is_safe_encoder_text(&s),
+                "C0 control {c:?} should be filtered"
+            );
+        }
+        assert!(!is_safe_encoder_text("\u{007F}"), "DEL should be filtered");
+
+        for c in ['\u{F700}', '\u{F701}', '\u{F702}', '\u{F703}', '\u{F8FF}'] {
+            let s = c.to_string();
+            assert!(
+                !is_safe_encoder_text(&s),
+                "macOS PUA {c:?} should be filtered"
+            );
+        }
+
+        assert!(!is_safe_encoder_text("a\u{F700}"));
+        assert!(!is_safe_encoder_text("\r\n"));
+    }
+
+    #[test]
+    fn safe_text_filter_passes_real_text() {
+        for s in ["a", "Z", "1", " ", "ø", "é", "ab", "你好", "😀"] {
+            assert!(is_safe_encoder_text(s), "{s:?} should pass through");
+        }
+        assert!(is_safe_encoder_text("\u{0020}"));
+        assert!(is_safe_encoder_text("\u{F6FF}"));
+        assert!(is_safe_encoder_text("\u{F900}"));
     }
 }

--- a/crates/seance-vt/src/session.rs
+++ b/crates/seance-vt/src/session.rs
@@ -768,7 +768,7 @@ mod unix_actor {
                         .sync_gate
                         .on_watchdog(self.sync_active(), Instant::now())
                 {
-                    let _ = self.publish_snapshot();
+                    let _ = self.publish_snapshot_if_dirty();
                 }
             }
 
@@ -871,7 +871,7 @@ mod unix_actor {
                     .sync_gate
                     .after_parse_batch(self.sync_active(), Instant::now())
             {
-                let _ = self.publish_snapshot();
+                let _ = self.publish_snapshot_if_dirty();
             }
             Ok(ReadOutcome::Alive)
         }
@@ -880,6 +880,25 @@ mod unix_actor {
             for bytes in self.core.drain_responses() {
                 self.pending_writes.push(bytes);
             }
+        }
+
+        /// Publish a snapshot only if the parse produced visible content
+        /// changes. Mode toggles like `\x1b[?2004h/l`, `\x1b[?2031h/l`, and
+        /// `\x1b[=Nu` round-trip through libghostty without dirtying any
+        /// rows; under rapid history navigation the shell emits a pair of
+        /// these around every prompt redraw, and forwarding them as
+        /// `PaneUpdate`s drives a full GPU redraw per keystroke for zero
+        /// painted-pixel difference. The actor keeps the generation
+        /// increment so subsequent real changes still ship with the
+        /// correct generation; only the slot push, the wake, and the
+        /// downstream redraw are skipped for the no-op snapshot.
+        fn publish_snapshot_if_dirty(&mut self) -> Result<(), VtCoreError> {
+            let snapshot = self.core.snapshot()?;
+            if matches!(snapshot.dirty, crate::frame::DirtySnapshot::Clean) {
+                return Ok(());
+            }
+            self.notifier.publish(Arc::new(snapshot));
+            Ok(())
         }
 
         fn publish_snapshot(&mut self) -> Result<(), VtCoreError> {


### PR DESCRIPTION
Holding ArrowUp through readline-driven shell history walked the right number of items in the shell, but the on-screen state lagged behind reality and Enter executed the item the shell was actually on — not the one visible. The lag is on the render side: as soon as the macOS auto-repeat rate exceeds what `draw()` can keep up with, the painted state falls behind, the user reads stale content as "current", and presses Enter against what they see.

Two contributing fixes.

`seance-vt`: skip `dirty=Clean` snapshot publishes. Every history press triggers the shell to emit a pair of mode toggles (`\x1b[?2004l \x1b[?2031l \x1b[=0u` then `\x1b[?2004h \x1b[?2031h \x1b[=5u`) around the actual prompt redraw. These round-trip through libghostty without dirtying any rows, but the actor used to publish anyway — the mux turned that into a `FrameDelta::Partial { dirty_rows: [] }`, the app called `mark_dirty`, and the next vsync scheduled a full GPU redraw for zero painted-pixel difference. Halving the per-press work lets the renderer stay caught up with a 30 Hz auto-repeat burst. The new `publish_snapshot_if_dirty` still extracts the snapshot (row cache + generation tracking depend on that) and only skips the slot push + wake when nothing visible changed. The eager `publish_snapshot` stays for resize / theme / cursor / scroll where the caller already knows something material changed.

`seance-input`: drop libghostty-forbidden codepoints from `set_utf8`. The encoder API explicitly forbids passing C0 controls (U+0000-U+001F, U+007F) or the macOS function-key PUA range (U+F700-U+F8FF) and tells callers to pass NULL instead so the encoder falls back to its logical-key path. winit puts exactly those codepoints into `event.text` for Enter (`\r`), Tab, Backspace, and every macOS arrow / function key. `is_safe_encoder_text` filters them out so the encoder always produces the documented VT sequence rather than relying on undefined behaviour around forbidden input. Covered by unit tests for the C0 boundaries, the PUA boundaries, and a handful of valid passthroughs (ASCII, Latin-1, CJK, emoji).

Closes #226