### PR TITLE
Add support for DECSET 1007 (alternate screen scroll)

### DIFF
--- a/crates/seance-app/src/events.rs
+++ b/crates/seance-app/src/events.rs
@@ -120,6 +120,8 @@ impl App {
         let modes = surface.terminal_modes();
         if let Some(data) = self.input.encode_mouse_wheel(lines, modes) {
             surface.write_to_pty(Bytes::from(data));
+        } else if let Some(data) = self.input.encode_alt_scroll(lines, modes) {
+            surface.write_to_pty(Bytes::from(data));
         } else {
             surface.scroll_lines(-lines);
         }

--- a/crates/seance-input/src/lib.rs
+++ b/crates/seance-input/src/lib.rs
@@ -198,6 +198,29 @@ impl InputHandler {
         if out.is_empty() { None } else { Some(out) }
     }
 
+    /// Encode wheel scrolling in the alternate screen as Up/Down arrow
+    /// sequences when DECSET 1007 (alternate scroll) is active. Returns
+    /// `None` when the alt-screen isn't active, 1007 is off, or `lines`
+    /// is zero — the caller falls back to local viewport scrolling, which
+    /// is itself a no-op in the alt-screen.
+    pub fn encode_alt_scroll(&self, lines: i32, modes: TerminalModes) -> Option<Vec<u8>> {
+        if !modes.alt_screen || !modes.alt_scroll || lines == 0 {
+            return None;
+        }
+        let seq: &[u8] = match (modes.cursor_keys, lines > 0) {
+            (true, true) => b"\x1bOA",
+            (true, false) => b"\x1bOB",
+            (false, true) => b"\x1b[A",
+            (false, false) => b"\x1b[B",
+        };
+        let count = lines.unsigned_abs() as usize;
+        let mut out = Vec::with_capacity(seq.len() * count);
+        for _ in 0..count {
+            out.extend_from_slice(seq);
+        }
+        Some(out)
+    }
+
     /// Encode a mouse button or motion event as VT mouse sequences. Returns
     /// `None` when mouse tracking is off, or when the event isn't reportable
     /// under the active sub-mode (motion under X10/Normal, motion without a
@@ -345,6 +368,19 @@ mod tests {
             mouse_tracking: tracking,
             mouse_format_sgr: sgr,
             bracketed_paste: false,
+            alt_screen: false,
+            alt_scroll: false,
+        }
+    }
+
+    fn alt_scroll_modes(alt_screen: bool, alt_scroll: bool, cursor_keys: bool) -> TerminalModes {
+        TerminalModes {
+            cursor_keys,
+            mouse_tracking: MouseTracking::None,
+            mouse_format_sgr: false,
+            bracketed_paste: false,
+            alt_screen,
+            alt_scroll,
         }
     }
 
@@ -496,5 +532,59 @@ mod tests {
         assert!(is_safe_encoder_text("\u{0020}"));
         assert!(is_safe_encoder_text("\u{F6FF}"));
         assert!(is_safe_encoder_text("\u{F900}"));
+    }
+
+    #[test]
+    fn alt_scroll_disabled_when_not_alt_screen() {
+        let h = InputHandler::new();
+        assert!(
+            h.encode_alt_scroll(3, alt_scroll_modes(false, true, false))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn alt_scroll_disabled_when_1007_off() {
+        let h = InputHandler::new();
+        assert!(
+            h.encode_alt_scroll(3, alt_scroll_modes(true, false, false))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn alt_scroll_csi_up_under_normal_cursor_keys() {
+        let h = InputHandler::new();
+        let out = h
+            .encode_alt_scroll(3, alt_scroll_modes(true, true, false))
+            .expect("alt-scroll should emit CSI up");
+        assert_eq!(out, b"\x1b[A\x1b[A\x1b[A");
+    }
+
+    #[test]
+    fn alt_scroll_csi_down_under_normal_cursor_keys() {
+        let h = InputHandler::new();
+        let out = h
+            .encode_alt_scroll(-2, alt_scroll_modes(true, true, false))
+            .expect("alt-scroll should emit CSI down");
+        assert_eq!(out, b"\x1b[B\x1b[B");
+    }
+
+    #[test]
+    fn alt_scroll_ss3_under_application_cursor_keys() {
+        let h = InputHandler::new();
+        let out = h
+            .encode_alt_scroll(1, alt_scroll_modes(true, true, true))
+            .expect("alt-scroll should emit SS3 up under DECCKM");
+        assert_eq!(out, b"\x1bOA");
+    }
+
+    #[test]
+    fn alt_scroll_zero_lines_returns_none() {
+        let h = InputHandler::new();
+        assert!(
+            h.encode_alt_scroll(0, alt_scroll_modes(true, true, false))
+                .is_none()
+        );
     }
 }

--- a/crates/seance-protocol/src/frame.rs
+++ b/crates/seance-protocol/src/frame.rs
@@ -81,6 +81,11 @@ pub struct TerminalModes {
     pub mouse_tracking: MouseTracking,
     pub mouse_format_sgr: bool,
     pub bracketed_paste: bool,
+    pub alt_screen: bool,
+    /// DECSET 1007: when set and `alt_screen` is true, the host translates
+    /// wheel events into Up/Down arrow sequences instead of touching the
+    /// (absent) alt-screen scrollback.
+    pub alt_scroll: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/seance-vt/src/snapshot_extraction.rs
+++ b/crates/seance-vt/src/snapshot_extraction.rs
@@ -4,6 +4,7 @@ use libghostty_vt::RenderState;
 use libghostty_vt::Terminal as VtTerminal;
 use libghostty_vt::error::Error as LibghosttyError;
 use libghostty_vt::render::{CellIteration, CellIterator, CursorVisualStyle, Dirty, RowIterator};
+use libghostty_vt::screen::Screen;
 use libghostty_vt::style::{self, PaletteIndex, RgbColor};
 use libghostty_vt::terminal::{Mode, Point, PointCoordinate};
 use seance_protocol::frame::RowMeta;
@@ -33,11 +34,17 @@ pub(crate) fn terminal_modes(vt: &VtTerminal<'static, 'static>) -> TerminalModes
     } else {
         MouseTracking::None
     };
+    let alt_screen = vt
+        .active_screen()
+        .map(|s| s == Screen::Alternate)
+        .unwrap_or(false);
     TerminalModes {
         cursor_keys: mode(Mode::DECCKM),
         mouse_tracking,
         mouse_format_sgr: mode(Mode::SGR_MOUSE),
         bracketed_paste: mode(Mode::BRACKETED_PASTE),
+        alt_screen,
+        alt_scroll: mode(Mode::ALT_SCROLL),
     }
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ Epic index:
 ┌─ input ──────────────────────────────────────────────────────────────┐
 │ winit event loop → seance-input                                      │
 │   key: KeyboardEvent → libghostty-vt key encoder → bytes             │
-│   mouse: wheel/click/drag → SGR 1006 / X10 encoding or ScrollLines   │
+│   mouse: click/drag → SGR 1006; wheel → 4/5, alt-arrows, or scroll   │
 │ UI sends mux PaneInput/ResizePane/ScrollLines                        │
 │ Local mux forwards to VT Actor, which writes PTY ─────────▶ shell    │
 └──────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
## Summary
Implement support for DECSET 1007 (alternate screen scroll mode), which allows wheel scroll events in the alternate screen to be translated into Up/Down arrow key sequences instead of attempting to scroll the (absent) alternate screen scrollback.

## Key Changes
- **seance-input**: Added `encode_alt_scroll()` method to `InputHandler` that encodes wheel scroll events as arrow key sequences (CSI or SS3 format depending on cursor key mode) when both alternate screen and DECSET 1007 are active
- **seance-protocol**: Extended `TerminalModes` struct with `alt_screen` and `alt_scroll` boolean fields to track these terminal modes
- **seance-vt**: Updated `terminal_modes()` function to extract alternate screen state and DECSET 1007 mode from the VT terminal
- **seance-app**: Modified wheel scroll event handling to fall back to `encode_alt_scroll()` when mouse wheel encoding is not applicable, before attempting local viewport scrolling
- **docs**: Updated architecture documentation to clarify wheel scroll behavior (4/5 encoding, alt-arrows, or local scroll)

## Implementation Details
- The `encode_alt_scroll()` method returns `None` when:
  - Alternate screen is not active
  - DECSET 1007 is disabled
  - Line count is zero (no scrolling needed)
- Arrow sequences are repeated based on the absolute value of the line count
- Respects the cursor key mode (DECCKM) to emit either CSI (`\x1b[A`/`\x1b[B`) or SS3 (`\x1bOA`/`\x1bOB`) sequences
- Comprehensive test coverage for all mode combinations and edge cases

https://claude.ai/code/session_01Lk1hdwDHue6zsK1LKyJChe