### PR TITLE
Set TERM and related environment variables for PTY sessions

### DIFF
--- a/crates/seance-vt/src/session.rs
+++ b/crates/seance-vt/src/session.rs
@@ -563,9 +563,10 @@ mod unix_actor {
                 })
                 .map_err(|err| SpawnError::Pty(err.to_string()))?;
             // GUI launches (e.g. macOS `.app` bundles) inherit no TERM from
-            // launchd, which leaves ncurses-based programs (htop, tmux) unable
-            // to start. Force a widely-installed terminfo entry so the child
-            // shell can describe us. Revisit if we ship our own terminfo.
+            // launchd, which leaves terminfo-based programs (htop via ncurses,
+            // tmux via libtinfo) unable to start. Force a widely-installed
+            // terminfo entry so the child shell can describe us. Revisit if we
+            // ship our own terminfo.
             let mut command = CommandBuilder::new_default_prog();
             command.env("TERM", "xterm-256color");
             command.env("COLORTERM", "truecolor");

--- a/crates/seance-vt/src/session.rs
+++ b/crates/seance-vt/src/session.rs
@@ -562,9 +562,18 @@ mod unix_actor {
                     pixel_height: options.pixel_height,
                 })
                 .map_err(|err| SpawnError::Pty(err.to_string()))?;
+            // GUI launches (e.g. macOS `.app` bundles) inherit no TERM from
+            // launchd, which leaves ncurses-based programs (htop, tmux) unable
+            // to start. Force a widely-installed terminfo entry so the child
+            // shell can describe us. Revisit if we ship our own terminfo.
+            let mut command = CommandBuilder::new_default_prog();
+            command.env("TERM", "xterm-256color");
+            command.env("COLORTERM", "truecolor");
+            command.env("TERM_PROGRAM", "seance");
+            command.env("TERM_PROGRAM_VERSION", env!("CARGO_PKG_VERSION"));
             let child = pair
                 .slave
-                .spawn_command(CommandBuilder::new_default_prog())
+                .spawn_command(command)
                 .map_err(|err| SpawnError::Pty(err.to_string()))?;
             let reader = pair
                 .master


### PR DESCRIPTION
## Summary
Configure terminal environment variables when spawning child shells in PTY sessions to ensure ncurses-based programs (htop, tmux, etc.) can function properly, particularly on macOS where launchd doesn't inherit TERM.

## Changes
- Set `TERM=xterm-256color` to provide a widely-supported terminfo entry for child processes
- Set `COLORTERM=truecolor` to advertise 24-bit color support
- Set `TERM_PROGRAM=seance` and `TERM_PROGRAM_VERSION` to identify the terminal emulator
- Build the command with these environment variables before spawning the PTY child process

## Implementation Details
The change addresses an issue where GUI application launches (e.g., macOS `.app` bundles) inherit no TERM variable from launchd, leaving ncurses-based programs unable to start. By explicitly setting these variables on the spawned shell, we ensure proper terminal capability negotiation. The xterm-256color entry is chosen as a widely-installed fallback; this approach can be revisited if custom terminfo is shipped in the future.

https://claude.ai/code/session_018sSigHLCNRyF6Wsh3mwemy