### PR TITLE
refactor(mux): deepen pane interaction state

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,7 +45,12 @@ or error semantics. _Avoid_: pane event, frame dirty event
 materialized into a VT Snapshot. _Avoid_: latest snapshot diff without base
 
 **Pane View**: Client-side pane state that materializes pane updates and owns
-selection/view state. _Avoid_: shared terminal state
+one Pane Interaction State. _Avoid_: shared terminal state
+
+**Pane Interaction State**: Per-client state for how one Pane View is being
+inspected or manipulated, including selection, copy mode, scrollback viewport,
+and hovered link. _Avoid_: shared selection, server-side copy mode, tmux-style
+pane state
 
 **Pane Handle**: The app-facing handle for one Pane View. It sends pane commands
 through the Mux Client and exposes render/copy state from the Pane View.
@@ -75,6 +80,9 @@ adapter
 - A **Mux Client** sends commands through exactly one **Domain**.
 - A **Mux Client** drains **Pane Updates** after a **Mux Wake**.
 - A **Mux Client** applies **Pane Updates** to **Pane Views**.
+- A **Pane View** owns exactly one **Pane Interaction State**.
+- **Pane Interaction State** is per **Mux Client** and is not shared through a
+  **Domain**.
 - A **Pane Handle** sends commands through its **Mux Client**.
 - A **Pane Handle** exposes render/copy state from one **Pane View**.
 - A **Pane View** materializes **Pane Updates** into a current **VT Snapshot**.
@@ -98,3 +106,6 @@ adapter
 - "terminal" can mean the app, the live libghostty terminal, or the user's
   shell. Use **VT Core**, **VT Actor**, **Pane Session**, or **VT Snapshot**
   when those are the intended concepts.
+- "selection" can mean shared tmux-style pane state or per-client UI state; in
+  séance, selection belongs to **Pane Interaction State** unless an explicit
+  shared protocol feature says otherwise.

--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -98,6 +98,10 @@ impl App {
                 surface.renderer.update_frame(&mut source);
             }
         }
+        let selection = surface.selection_range();
+        let hovered_link = surface.hovered_link_range();
+        surface.render_inputs.selection = selection;
+        surface.render_inputs.hovered_link = hovered_link;
         // Prefer the VT-reported shape; fall back to the user's configured
         // default when the VT has no opinion. Refreshed every frame so that
         // hot-reload of `cursor.style` is picked up without extra wiring.
@@ -212,9 +216,13 @@ impl ApplicationHandler<UserEvent> for App {
 
         let (cols, rows) = renderer.grid_size();
         let proxy = self.proxy.clone();
-        let mut mux = MuxClient::new(LocalDomain::new(move |event| {
-            let _ = proxy.send_event(UserEvent::Mux(event));
-        }));
+        let link_detector = link_detector_from_config(&self.config.links);
+        let mut mux = MuxClient::with_link_detector(
+            LocalDomain::new(move |event| {
+                let _ = proxy.send_event(UserEvent::Mux(event));
+            }),
+            link_detector,
+        );
         let active_pane = mux
             .spawn_pane(PaneSpawnOptions {
                 cols,
@@ -230,15 +238,7 @@ impl ApplicationHandler<UserEvent> for App {
             cursor_shape: self.config.cursor.style.into(),
             ..RenderInputs::default()
         };
-        let link_detector = link_detector_from_config(&self.config.links);
-        let mut surface = SurfaceState::new(
-            window,
-            renderer,
-            mux,
-            active_pane,
-            render_inputs,
-            link_detector,
-        );
+        let mut surface = SurfaceState::new(window, renderer, mux, active_pane, render_inputs);
         self.apply_terminal_theme_to(&mut surface, &theme);
         self.surface = Some(surface);
 

--- a/crates/seance-app/src/events.rs
+++ b/crates/seance-app/src/events.rs
@@ -87,7 +87,6 @@ impl App {
             AppCommand::SelectAll => {
                 if let Some(surface) = self.surface_mut() {
                     surface.select_all();
-                    surface.sync_selection_to_overlay();
                     surface.mark_dirty();
                 }
             }
@@ -157,7 +156,6 @@ impl App {
         let (col, row) = surface.renderer.pixel_to_grid(position.x, position.y);
         if surface.mouse.is_down {
             surface.update_selection(col, row);
-            surface.sync_selection_to_overlay();
             surface.mark_dirty();
         }
         surface.refresh_hovered_link();
@@ -238,7 +236,6 @@ fn handle_mouse_press(surface: &mut SurfaceState) {
         3 => surface.start_line_selection(row),
         _ => {}
     }
-    surface.sync_selection_to_overlay();
     surface.mouse.is_down = true;
     surface.mark_dirty();
 }

--- a/crates/seance-app/src/reload.rs
+++ b/crates/seance-app/src/reload.rs
@@ -133,7 +133,9 @@ impl App {
         if diff.links_changed
             && let Some(surface) = self.surface.as_mut()
         {
-            surface.link_detector = link_detector_from_config(&self.config.links);
+            surface
+                .mux
+                .set_link_detector(link_detector_from_config(&self.config.links));
             surface.refresh_hovered_link();
         }
         if old_config.cursor.style != self.config.cursor.style

--- a/crates/seance-app/src/surface_state.rs
+++ b/crates/seance-app/src/surface_state.rs
@@ -14,8 +14,8 @@ use winit::event::Modifiers;
 use winit::window::{CursorIcon, Window};
 
 use seance_mux::{
-    ClientRefresh, CursorShape as MuxCursorShape, DetectedLink, GridPos, LinkDetector,
-    LinkModifiers, LinkTarget, LocalDomain, MuxClient, PaneRef, Resize, TerminalModes, ThemeColors,
+    ClientRefresh, CursorShape as MuxCursorShape, DetectedLink, GridPos, LinkModifiers, LinkTarget,
+    LocalDomain, MuxClient, PaneRef, Resize, TerminalModes, ThemeColors,
 };
 use seance_render::{HoveredLinkRange, RenderInputs, TerminalRenderer};
 
@@ -27,7 +27,6 @@ pub(crate) struct SurfaceState {
     pub(crate) mux: MuxClient<LocalDomain>,
     pub(crate) active_pane: PaneRef,
     pub(crate) render_inputs: RenderInputs,
-    pub(crate) link_detector: LinkDetector,
     pub(crate) modifiers: Modifiers,
     pub(crate) cell_size: [f32; 2],
     pub(crate) content_dirty: bool,
@@ -45,7 +44,6 @@ impl SurfaceState {
         mux: MuxClient<LocalDomain>,
         active_pane: PaneRef,
         render_inputs: RenderInputs,
-        link_detector: LinkDetector,
     ) -> Self {
         let cell_size = renderer.cell_size();
         Self {
@@ -54,7 +52,6 @@ impl SurfaceState {
             mux,
             active_pane,
             render_inputs,
-            link_detector,
             modifiers: Modifiers::default(),
             cell_size,
             content_dirty: true,
@@ -155,17 +152,12 @@ impl SurfaceState {
 
     pub(crate) fn clear_selection(&mut self) {
         self.mux.pane(self.active_pane).clear_selection();
-        self.render_inputs.selection = None;
     }
 
     pub(crate) fn selection_range(&self) -> Option<(GridPos, GridPos)> {
         self.mux
             .pane_view(self.active_pane)
             .and_then(|view| view.selection_range())
-    }
-
-    pub(crate) fn sync_selection_to_overlay(&mut self) {
-        self.render_inputs.selection = self.selection_range();
     }
 
     pub(crate) fn start_selection(&mut self, col: u16, row: u16) {
@@ -208,38 +200,45 @@ impl SurfaceState {
     }
 
     pub(crate) fn refresh_hovered_link(&mut self) {
-        let new_link = self.current_link_at_cursor().map(|link| HoveredLinkRange {
-            start: link.range.start,
-            end: link.range.end,
-        });
-        if self.render_inputs.hovered_link == new_link {
-            return;
-        }
-        let now_active = new_link.is_some();
-        self.render_inputs.hovered_link = new_link;
-        self.window.set_cursor(if now_active {
+        self.update_hover_input();
+        let new_link = self.hovered_link_range();
+        self.window.set_cursor(if new_link.is_some() {
             CursorIcon::Pointer
         } else {
             CursorIcon::Default
         });
-        self.mark_dirty();
+        if self.render_inputs.hovered_link != new_link {
+            self.mark_dirty();
+        }
     }
 
-    pub(crate) fn current_link_at_cursor(&self) -> Option<DetectedLink> {
-        let pos = self.current_hover_cell();
-        let modifiers = self.link_modifiers();
+    pub(crate) fn hovered_link_range(&self) -> Option<HoveredLinkRange> {
         self.mux
-            .pane_view(self.active_pane)?
-            .link_at(pos, &self.link_detector, modifiers)
+            .hovered_link_range(self.active_pane)
+            .map(|range| HoveredLinkRange {
+                start: range.start,
+                end: range.end,
+            })
     }
 
-    pub(crate) fn current_link_target(&self) -> Option<(LinkTarget, Option<String>)> {
+    pub(crate) fn current_link_at_cursor(&mut self) -> Option<DetectedLink> {
+        self.update_hover_input();
+        self.mux.hovered_link(self.active_pane)
+    }
+
+    pub(crate) fn current_link_target(&mut self) -> Option<(LinkTarget, Option<String>)> {
         let link = self.current_link_at_cursor()?;
         let pwd = self
             .mux
             .pane_view(self.active_pane)
             .and_then(|view| view.pwd().map(str::to_owned));
         Some((link.target, pwd))
+    }
+
+    fn update_hover_input(&mut self) {
+        let pos = self.current_hover_cell();
+        let modifiers = self.link_modifiers();
+        let _ = self.mux.set_hover_input(self.active_pane, pos, modifiers);
     }
 
     fn current_hover_cell(&self) -> GridPos {

--- a/crates/seance-mux/src/client.rs
+++ b/crates/seance-mux/src/client.rs
@@ -5,20 +5,26 @@ use seance_protocol::frame::{CursorShape, GridPos, Resize, TerminalModes, ThemeC
 use seance_protocol::identity::PaneRef;
 
 use crate::{
-    ClientRefresh, Domain, DomainEvent, PaneError, PaneFrame, PaneSpawnOptions, PaneView,
-    SpawnError,
+    ClientRefresh, DetectedLink, Domain, DomainEvent, GridRange, LinkDetector, LinkModifiers,
+    PaneError, PaneFrame, PaneSpawnOptions, PaneView, SpawnError,
 };
 
 pub struct MuxClient<D> {
     domain: D,
+    link_detector: LinkDetector,
     active: Option<PaneRef>,
     views: HashMap<PaneRef, PaneView>,
 }
 
 impl<D> MuxClient<D> {
     pub fn new(domain: D) -> Self {
+        Self::with_link_detector(domain, LinkDetector::disabled())
+    }
+
+    pub fn with_link_detector(domain: D, link_detector: LinkDetector) -> Self {
         Self {
             domain,
+            link_detector,
             active: None,
             views: HashMap::new(),
         }
@@ -30,6 +36,14 @@ impl<D> MuxClient<D> {
 
     pub fn domain_mut(&mut self) -> &mut D {
         &mut self.domain
+    }
+
+    pub fn link_detector(&self) -> &LinkDetector {
+        &self.link_detector
+    }
+
+    pub fn set_link_detector(&mut self, link_detector: LinkDetector) {
+        self.link_detector = link_detector;
     }
 
     pub fn active_pane_ref(&self) -> Option<PaneRef> {
@@ -51,6 +65,28 @@ impl<D> MuxClient<D> {
 
     pub fn pane_view_mut(&mut self, pane: PaneRef) -> Option<&mut PaneView> {
         self.views.get_mut(&pane)
+    }
+
+    pub fn set_hover_input(
+        &mut self,
+        pane: PaneRef,
+        pos: GridPos,
+        modifiers: LinkModifiers,
+    ) -> Result<bool, PaneError> {
+        self.views
+            .get_mut(&pane)
+            .map(|view| view.set_hover_input(pos, modifiers))
+            .ok_or_else(|| PaneError::new("unknown pane"))
+    }
+
+    pub fn hovered_link(&self, pane: PaneRef) -> Option<DetectedLink> {
+        self.views
+            .get(&pane)
+            .and_then(|view| view.hovered_link(&self.link_detector))
+    }
+
+    pub fn hovered_link_range(&self, pane: PaneRef) -> Option<GridRange> {
+        self.hovered_link(pane).map(|link| link.range)
     }
 
     pub fn pane(&mut self, pane: PaneRef) -> PaneHandle<'_, D> {
@@ -180,6 +216,20 @@ impl<D> PaneHandle<'_, D> {
 
     pub fn selection_text(&self) -> Option<String> {
         self.view().and_then(PaneView::selection_text)
+    }
+
+    pub fn set_hover_input(&mut self, pos: GridPos, modifiers: LinkModifiers) -> bool {
+        self.view_mut()
+            .is_some_and(|view| view.set_hover_input(pos, modifiers))
+    }
+
+    pub fn hovered_link(&self) -> Option<DetectedLink> {
+        self.view()
+            .and_then(|view| view.hovered_link(&self.client.link_detector))
+    }
+
+    pub fn hovered_link_range(&self) -> Option<GridRange> {
+        self.hovered_link().map(|link| link.range)
     }
 
     fn view(&self) -> Option<&PaneView> {

--- a/crates/seance-mux/src/interaction.rs
+++ b/crates/seance-mux/src/interaction.rs
@@ -1,0 +1,87 @@
+use seance_protocol::frame::{GridPos, Selection};
+
+use crate::links::LinkModifiers;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HoverInput {
+    pub cell: GridPos,
+    pub modifiers: LinkModifiers,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PaneInteractionState {
+    selection: Option<Selection>,
+    hover: Option<HoverInput>,
+}
+
+impl PaneInteractionState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn hover_input(&self) -> Option<HoverInput> {
+        self.hover
+    }
+
+    pub fn set_hover_input(&mut self, cell: GridPos, modifiers: LinkModifiers) -> bool {
+        let next = Some(HoverInput { cell, modifiers });
+        if self.hover == next {
+            false
+        } else {
+            self.hover = next;
+            true
+        }
+    }
+
+    pub fn clear_hover_input(&mut self) -> bool {
+        if self.hover.is_none() {
+            false
+        } else {
+            self.hover = None;
+            true
+        }
+    }
+
+    pub fn has_selection(&self) -> bool {
+        self.selection.is_some()
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.selection = None;
+    }
+
+    pub fn selection(&self) -> Option<&Selection> {
+        self.selection.as_ref()
+    }
+
+    pub fn selection_range(&self) -> Option<(GridPos, GridPos)> {
+        self.selection.as_ref().map(Selection::ordered_range)
+    }
+
+    pub fn start_selection(&mut self, col: u16, row: u16) {
+        self.selection = Some(Selection::new(GridPos { col, row }));
+    }
+
+    pub fn start_word_selection(&mut self, col: u16, row: u16) {
+        self.selection = Some(Selection::new_word(GridPos { col, row }));
+    }
+
+    pub fn start_line_selection(&mut self, row: u16) {
+        self.selection = Some(Selection::new_line(GridPos { col: 0, row }));
+    }
+
+    pub fn update_selection(&mut self, col: u16, row: u16) {
+        if let Some(selection) = &mut self.selection {
+            selection.update(GridPos { col, row });
+        }
+    }
+
+    pub fn select_all(&mut self, cols: u16, rows: u16) {
+        let mut selection = Selection::new_line(GridPos { col: 0, row: 0 });
+        selection.update(GridPos {
+            col: cols.saturating_sub(1),
+            row: rows.saturating_sub(1),
+        });
+        self.selection = Some(selection);
+    }
+}

--- a/crates/seance-mux/src/lib.rs
+++ b/crates/seance-mux/src/lib.rs
@@ -3,6 +3,7 @@ mod domain;
 mod error;
 mod events;
 mod history;
+mod interaction;
 pub mod links;
 mod local;
 mod pane_view;
@@ -13,6 +14,7 @@ pub use domain::{Domain, PaneSpawnOptions};
 pub use error::{PaneError, SpawnError};
 pub use events::{ClientRefresh, DomainEvent, MuxEvent};
 pub use history::{PaneFrameHistory, ReplayBatch};
+pub use interaction::{HoverInput, PaneInteractionState};
 pub use links::{
     DetectedLink, GridRange, LinkAction, LinkDetector, LinkHighlight, LinkModifiers, LinkRule,
     LinkSource, LinkTarget,

--- a/crates/seance-mux/src/links/mod.rs
+++ b/crates/seance-mux/src/links/mod.rs
@@ -96,12 +96,22 @@ impl LinkRule {
 }
 
 pub struct LinkDetector {
+    enabled: bool,
     activation_mods: LinkModifiers,
     rules: Vec<LinkRule>,
     default_rule: Option<Regex>,
 }
 
 impl LinkDetector {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            activation_mods: LinkModifiers::default(),
+            rules: Vec::new(),
+            default_rule: None,
+        }
+    }
+
     pub fn default_ghostty_like(mods: LinkModifiers) -> Self {
         Self::from_options(mods, true, true).expect("default link regex should compile")
     }
@@ -112,6 +122,7 @@ impl LinkDetector {
         paths: bool,
     ) -> Result<Self, fancy_regex::Error> {
         Ok(Self {
+            enabled: true,
             activation_mods,
             rules: Vec::new(),
             default_rule: default_url::compile(urls, paths)?,
@@ -128,7 +139,7 @@ impl LinkDetector {
         pos: GridPos,
         mods: LinkModifiers,
     ) -> Option<DetectedLink> {
-        if !self.activation_mods.matches(mods) {
+        if !self.enabled || !self.activation_mods.matches(mods) {
             return None;
         }
 

--- a/crates/seance-mux/src/pane_view.rs
+++ b/crates/seance-mux/src/pane_view.rs
@@ -2,13 +2,14 @@ use std::sync::Arc;
 
 use seance_frame::SnapshotFrameSource;
 use seance_protocol::frame::{
-    CursorShape, DirtySnapshot, FrameDelta, GridPos, HyperlinkRun, Selection, TerminalModes,
-    VtSnapshot, apply_frame_delta,
+    CursorShape, DirtySnapshot, FrameDelta, GridPos, HyperlinkRun, TerminalModes, VtSnapshot,
+    apply_frame_delta,
 };
 use seance_protocol::identity::{PaneRef, ServerSeq};
 use seance_protocol::mux::PaneUpdate;
 
 use crate::PaneError;
+use crate::interaction::{HoverInput, PaneInteractionState};
 use crate::links::{DetectedLink, LinkDetector, LinkModifiers};
 
 pub type PaneFrame<'a> = SnapshotFrameSource<'a>;
@@ -16,7 +17,7 @@ pub type PaneFrame<'a> = SnapshotFrameSource<'a>;
 pub struct PaneView {
     pane: PaneRef,
     latest_snapshot: Option<Arc<VtSnapshot>>,
-    selection: Option<Selection>,
+    interaction: PaneInteractionState,
     last_applied_seq: Option<ServerSeq>,
 }
 
@@ -25,7 +26,7 @@ impl PaneView {
         Self {
             pane,
             latest_snapshot: None,
-            selection: None,
+            interaction: PaneInteractionState::new(),
             last_applied_seq: None,
         }
     }
@@ -87,47 +88,52 @@ impl PaneView {
             .and_then(|snapshot| snapshot.pwd.as_deref())
     }
 
+    pub fn hover_input(&self) -> Option<HoverInput> {
+        self.interaction.hover_input()
+    }
+
+    pub fn set_hover_input(&mut self, pos: GridPos, modifiers: LinkModifiers) -> bool {
+        self.interaction.set_hover_input(pos, modifiers)
+    }
+
+    pub fn clear_hover_input(&mut self) -> bool {
+        self.interaction.clear_hover_input()
+    }
+
     pub fn has_selection(&self) -> bool {
-        self.selection.is_some()
+        self.interaction.has_selection()
     }
 
     pub fn clear_selection(&mut self) {
-        self.selection = None;
+        self.interaction.clear_selection();
     }
 
     pub fn selection_range(&self) -> Option<(GridPos, GridPos)> {
-        self.selection.as_ref().map(Selection::ordered_range)
+        self.interaction.selection_range()
     }
 
     pub fn start_selection(&mut self, col: u16, row: u16) {
-        self.selection = Some(Selection::new(GridPos { col, row }));
+        self.interaction.start_selection(col, row);
     }
 
     pub fn start_word_selection(&mut self, col: u16, row: u16) {
-        self.selection = Some(Selection::new_word(GridPos { col, row }));
+        self.interaction.start_word_selection(col, row);
     }
 
     pub fn start_line_selection(&mut self, row: u16) {
-        self.selection = Some(Selection::new_line(GridPos { col: 0, row }));
+        self.interaction.start_line_selection(row);
     }
 
     pub fn update_selection(&mut self, col: u16, row: u16) {
-        if let Some(selection) = &mut self.selection {
-            selection.update(GridPos { col, row });
-        }
+        self.interaction.update_selection(col, row);
     }
 
     pub fn select_all(&mut self, cols: u16, rows: u16) {
-        let mut selection = Selection::new_line(GridPos { col: 0, row: 0 });
-        selection.update(GridPos {
-            col: cols.saturating_sub(1),
-            row: rows.saturating_sub(1),
-        });
-        self.selection = Some(selection);
+        self.interaction.select_all(cols, rows);
     }
 
     pub fn selection_text(&self) -> Option<String> {
-        let selection = self.selection.as_ref()?;
+        let selection = self.interaction.selection()?;
         let snapshot = self.latest_snapshot.as_ref()?;
         snapshot.selection_text(selection)
     }
@@ -136,6 +142,11 @@ impl PaneView {
         self.latest_snapshot
             .as_ref()
             .and_then(|snapshot| snapshot.osc8_run_at(col, row))
+    }
+
+    pub fn hovered_link(&self, detector: &LinkDetector) -> Option<DetectedLink> {
+        let input = self.hover_input()?;
+        self.link_at(input.cell, detector, input.modifiers)
     }
 
     pub fn link_at(

--- a/crates/seance-mux/src/tests.rs
+++ b/crates/seance-mux/src/tests.rs
@@ -14,8 +14,9 @@ use seance_protocol::transport::{
 };
 
 use crate::{
-    CursorShape, Domain, DomainEvent, MuxClient, PaneError, PaneFrameHistory, PaneSpawnOptions,
-    PaneView, ProtocolDomain, ReplayBatch, Resize, SpawnError, ThemeColors,
+    CursorShape, Domain, DomainEvent, LinkDetector, LinkModifiers, LinkSource, LinkTarget,
+    MuxClient, PaneError, PaneFrameHistory, PaneSpawnOptions, PaneView, ProtocolDomain,
+    ReplayBatch, Resize, SpawnError, ThemeColors,
 };
 
 fn pane_ref() -> PaneRef {
@@ -194,6 +195,83 @@ fn mux_client_refresh_collects_image_events() {
     assert_eq!(refresh.image_events, vec![event]);
     assert!(refresh.frame_dirty);
     assert_eq!(client.pane_view(pane).unwrap().generation(), Some(1));
+}
+
+#[test]
+fn mux_client_derives_hovered_link_from_pane_interaction_state() {
+    let pane = pane_ref();
+    let mut frame = snapshot(1, "x");
+    let idx = frame.intern_hyperlink("https://example.com");
+    frame.cells[0].hyperlink_idx = idx;
+    let update = PaneUpdate {
+        pane,
+        seq: ServerSeq(1),
+        image_events: Vec::new(),
+        frame: Some(FrameDelta::Full {
+            generation: 1,
+            snapshot: frame,
+        }),
+    };
+    let mods = LinkModifiers {
+        super_key: true,
+        shift: true,
+        ..LinkModifiers::default()
+    };
+    let mut client = MuxClient::with_link_detector(
+        ScriptedDomain {
+            events: VecDeque::from([DomainEvent::PaneUpdate(update)]),
+            ..ScriptedDomain::default()
+        },
+        LinkDetector::from_options(mods, false, false).unwrap(),
+    );
+
+    let pane = client.spawn_pane(PaneSpawnOptions::default()).unwrap();
+    client
+        .set_hover_input(
+            pane,
+            seance_protocol::frame::GridPos { col: 0, row: 0 },
+            mods,
+        )
+        .unwrap();
+
+    let link = client.hovered_link(pane).unwrap();
+    assert_eq!(link.source, LinkSource::Osc8);
+    assert_eq!(
+        link.target,
+        LinkTarget::Url("https://example.com".to_string())
+    );
+}
+
+#[test]
+fn mux_client_new_uses_disabled_link_detector() {
+    let pane = pane_ref();
+    let mut frame = snapshot(1, "x");
+    let idx = frame.intern_hyperlink("https://example.com");
+    frame.cells[0].hyperlink_idx = idx;
+    let update = PaneUpdate {
+        pane,
+        seq: ServerSeq(1),
+        image_events: Vec::new(),
+        frame: Some(FrameDelta::Full {
+            generation: 1,
+            snapshot: frame,
+        }),
+    };
+    let mut client = MuxClient::new(ScriptedDomain {
+        events: VecDeque::from([DomainEvent::PaneUpdate(update)]),
+        ..ScriptedDomain::default()
+    });
+
+    let pane = client.spawn_pane(PaneSpawnOptions::default()).unwrap();
+    client
+        .set_hover_input(
+            pane,
+            seance_protocol::frame::GridPos { col: 0, row: 0 },
+            LinkModifiers::default(),
+        )
+        .unwrap();
+
+    assert_eq!(client.hovered_link(pane), None);
 }
 
 #[test]


### PR DESCRIPTION
Pane interaction state is per-client UI state, not shared terminal truth. Keeping selection and hover bookkeeping in seance-app made the app responsible for syncing render overlays and link policy alongside OS adapters.

Move the per-client state into the mux-side Pane View path so future tabs, splits, and remote Domain adapters can reuse the same rules while seance-app keeps window, clipboard, cursor, and launcher adapters.

Tests: cargo fmt --all; cargo check --workspace; cargo test -p seance-mux; cargo test -p seance-app; cargo clippy --workspace --all-targets -- -D warnings; npx --yes prettier --check CONTEXT.md; npx --yes markdownlint-cli2 CONTEXT.md

No tracked issue.