### PR TITLE
Make scrollback limit configurable and respect config changes

### DIFF
--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -222,6 +222,7 @@ impl ApplicationHandler<UserEvent> for App {
                 pixel_width: size.width as u16,
                 pixel_height: size.height as u16,
                 initial_cursor_shape: mux_shape_from_config(self.config.cursor.style),
+                max_scrollback: self.config.scrollback.limit as usize,
             })
             .expect("failed to spawn local pane");
         tracing::info!(pane = ?active_pane, cols, rows, "pane spawned");

--- a/crates/seance-app/src/reload.rs
+++ b/crates/seance-app/src/reload.rs
@@ -117,6 +117,11 @@ impl App {
                 "font.family change takes effect on restart (live swap not yet supported)"
             );
         }
+        if diff.scrollback_limit_changed {
+            tracing::info!(
+                "scrollback.limit change takes effect on restart (live swap not yet supported)"
+            );
+        }
         if diff.theme_changed {
             self.reload_theme();
         }

--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -49,6 +49,10 @@ pub struct ConfigDiff {
     pub input_changed: bool,
     /// `[links]` section changed — caller must rebuild link detection state.
     pub links_changed: bool,
+    /// `scrollback.limit` changed — rebuilding the VT scrollback buffer
+    /// requires respawning the actor, which the live reload path does not do
+    /// today. Caller logs a notice telling the user to restart.
+    pub scrollback_limit_changed: bool,
 }
 
 impl ConfigDiff {
@@ -78,6 +82,7 @@ impl ConfigDiff {
 
         let input_changed = old.input.macos_option_as_alt != new.input.macos_option_as_alt;
         let links_changed = old.links != new.links;
+        let scrollback_limit_changed = old.scrollback.limit != new.scrollback.limit;
 
         Self {
             theme_changed,
@@ -91,6 +96,7 @@ impl ConfigDiff {
             repaint_only,
             input_changed,
             links_changed,
+            scrollback_limit_changed,
         }
     }
 
@@ -106,7 +112,8 @@ impl ConfigDiff {
             || self.window_padding_changed
             || self.repaint_only
             || self.input_changed
-            || self.links_changed)
+            || self.links_changed
+            || self.scrollback_limit_changed)
     }
 }
 
@@ -249,6 +256,18 @@ mod tests {
         assert!(d.links_changed);
         assert!(!d.repaint_only);
         assert!(!d.theme_changed);
+    }
+
+    #[test]
+    fn scrollback_limit_change_is_detected_separately() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.scrollback.limit = a.scrollback.limit + 1;
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.scrollback_limit_changed);
+        assert!(!d.repaint_only);
+        assert!(!d.theme_changed);
+        assert!(!d.is_empty());
     }
 
     #[test]

--- a/crates/seance-mux/src/domain.rs
+++ b/crates/seance-mux/src/domain.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use seance_protocol::frame::{CursorShape, Resize, ThemeColors};
 use seance_protocol::identity::PaneRef;
+use seance_vt::DEFAULT_MAX_SCROLLBACK;
 
 use crate::{DomainEvent, PaneError, SpawnError};
 
@@ -11,6 +12,7 @@ pub struct PaneSpawnOptions {
     pub pixel_width: u16,
     pub pixel_height: u16,
     pub initial_cursor_shape: CursorShape,
+    pub max_scrollback: usize,
 }
 
 impl Default for PaneSpawnOptions {
@@ -21,6 +23,7 @@ impl Default for PaneSpawnOptions {
             pixel_width: 800,
             pixel_height: 384,
             initial_cursor_shape: CursorShape::Block,
+            max_scrollback: DEFAULT_MAX_SCROLLBACK,
         }
     }
 }
@@ -33,6 +36,7 @@ impl From<PaneSpawnOptions> for seance_vt::VtSessionOptions {
             pixel_width: value.pixel_width,
             pixel_height: value.pixel_height,
             initial_cursor_shape: value.initial_cursor_shape,
+            max_scrollback: value.max_scrollback,
         }
     }
 }
@@ -53,4 +57,19 @@ pub trait Domain {
     fn set_cursor_shape(&mut self, pane: PaneRef, shape: CursorShape) -> Result<(), PaneError>;
 
     fn ack_presented(&mut self, pane: PaneRef, generation: u64) -> Result<(), PaneError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pane_spawn_options_propagate_max_scrollback_to_vt() {
+        let options = PaneSpawnOptions {
+            max_scrollback: 12_345,
+            ..PaneSpawnOptions::default()
+        };
+        let vt: seance_vt::VtSessionOptions = options.into();
+        assert_eq!(vt.max_scrollback, 12_345);
+    }
 }

--- a/crates/seance-vt/src/core.rs
+++ b/crates/seance-vt/src/core.rs
@@ -12,7 +12,7 @@ use crate::snapshot::{RowMeta, VtSnapshot};
 use crate::snapshot_extraction::{SnapshotExtraction, extract_snapshot};
 use crate::terminal::install_png_decoder_for_this_thread;
 
-pub(crate) const DEFAULT_MAX_SCROLLBACK: usize = 10_000;
+pub const DEFAULT_MAX_SCROLLBACK: usize = 10_000;
 pub(crate) const KITTY_IMAGE_STORAGE_LIMIT_BYTES: u64 = 320 * 1000 * 1000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/seance-vt/src/lib.rs
+++ b/crates/seance-vt/src/lib.rs
@@ -18,7 +18,7 @@ mod terminal;
 #[doc(hidden)]
 pub mod test_support;
 
-pub use core::VtCoreError;
+pub use core::{DEFAULT_MAX_SCROLLBACK, VtCoreError};
 pub use frame::{
     CellAttrs, CellColor, CellView, CellVisitor, CursorInfo, CursorShape, DirtySnapshot,
     FrameSource, ImageInfo, ImageVisitor, PlacementLayer, PlacementSnapshot, PlacementVisitor,

--- a/crates/seance-vt/src/session.rs
+++ b/crates/seance-vt/src/session.rs
@@ -36,6 +36,7 @@ pub struct VtSessionOptions {
     pub pixel_width: u16,
     pub pixel_height: u16,
     pub initial_cursor_shape: CursorShape,
+    pub max_scrollback: usize,
 }
 
 impl Default for VtSessionOptions {
@@ -46,6 +47,7 @@ impl Default for VtSessionOptions {
             pixel_width: 800,
             pixel_height: 384,
             initial_cursor_shape: CursorShape::Block,
+            max_scrollback: crate::core::DEFAULT_MAX_SCROLLBACK,
         }
     }
 }
@@ -478,7 +480,7 @@ mod unix_actor {
     use polling::{Event, Events, Poller};
     use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 
-    use crate::core::{DEFAULT_MAX_SCROLLBACK, VtCore, VtCoreOptions};
+    use crate::core::{VtCore, VtCoreOptions};
 
     pub(super) fn spawn_vt_session_unix<F>(
         options: VtSessionOptions,
@@ -677,7 +679,7 @@ mod unix_actor {
                 rows: options.rows,
                 pixel_width: options.pixel_width,
                 pixel_height: options.pixel_height,
-                max_scrollback: DEFAULT_MAX_SCROLLBACK,
+                max_scrollback: options.max_scrollback,
                 initial_cursor_shape: options.initial_cursor_shape,
             })
             .map_err(SpawnError::VtCore)?;
@@ -1053,6 +1055,7 @@ mod unix_actor {
                     pixel_width: 80,
                     pixel_height: 30,
                     initial_cursor_shape: CursorShape::Block,
+                    ..VtSessionOptions::default()
                 },
                 ScriptedPtyAdapter::new(reads),
                 rx,
@@ -1417,6 +1420,7 @@ mod tests {
                 pixel_width: 80,
                 pixel_height: 40,
                 initial_cursor_shape: CursorShape::Block,
+                ..VtSessionOptions::default()
             },
             move |event| sink_events.lock().unwrap().push(event),
         )


### PR DESCRIPTION
## Summary
This change makes the VT scrollback buffer limit configurable through the `scrollback.limit` config option and ensures that changes to this setting are properly detected and communicated to users.

## Key Changes
- Added `scrollback_limit_changed` field to `ConfigDiff` to detect when `scrollback.limit` changes in the configuration
- Exported `DEFAULT_MAX_SCROLLBACK` constant from `seance_vt` crate to make it available for use in other modules
- Added `max_scrollback` field to `PaneSpawnOptions` and `VtSessionOptions` to allow configurable scrollback limits when spawning panes
- Updated pane spawning logic in `App` to pass the configured `scrollback.limit` value when creating new panes
- Added logging in the reload handler to inform users that scrollback limit changes require a restart (live reload not yet supported)
- Added comprehensive tests to verify scrollback limit change detection and propagation through the spawn options

## Implementation Details
- The scrollback limit is now threaded through the spawn options chain: `App` → `PaneSpawnOptions` → `VtSessionOptions` → `VtCore`
- When config is reloaded, if `scrollback.limit` changes, a notice is logged informing the user to restart the application
- The change maintains backward compatibility by using `DEFAULT_MAX_SCROLLBACK` as the default value throughout the stack
- Tests verify that the scrollback limit is properly detected as a configuration change and correctly propagated to the VT session

https://claude.ai/code/session_01Cth7RtiXVy4bfNdPuXhxCd