### PR TITLE
fix(render): avoid boosting explicit colors

### DIFF
--- a/crates/seance-config/src/lib.rs
+++ b/crates/seance-config/src/lib.rs
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(cfg.theme.as_deref(), Some("Catppuccin Mocha"));
         assert_eq!(cfg.font.family, "Berkeley Mono");
         assert_eq!(cfg.font.size, 16.0);
-        assert_eq!(cfg.font.min_contrast, 1.1);
+        assert_eq!(cfg.font.min_contrast, 1.0);
         assert_eq!(
             cfg.font.features,
             vec!["calt".to_string(), "liga".to_string()]

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -58,7 +58,7 @@ impl Default for FontConfig {
             features: vec!["calt".to_string(), "liga".to_string()],
             adjust_cell_height: None,
             adjust_cell_width: None,
-            min_contrast: 1.1,
+            min_contrast: 1.0,
             fallback: Vec::new(),
         }
     }

--- a/crates/seance-render/src/gpu/shaders/cell.wgsl
+++ b/crates/seance-render/src/gpu/shaders/cell.wgsl
@@ -33,6 +33,10 @@ struct Uniforms {
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
+const ATLAS_MASK: u32 = 0xFFu;
+const CURSOR_GLYPH_FLAGS_MASK: u32 = 0xFF00u;
+const MIN_CONTRAST_FLAG: u32 = 0x10000u;
+
 // ================================================================
 // Min-contrast (WCAG relative luminance in linearized sRGB)
 // ================================================================
@@ -257,6 +261,7 @@ struct CellTextOut {
     @location(1) @interpolate(flat) color: vec4<f32>,
     @location(2) @interpolate(flat) atlas: u32,
     @location(3) @interpolate(flat) bg_color: vec3<f32>,
+    @location(4) @interpolate(flat) min_contrast: u32,
 }
 
 @group(2) @binding(0) var atlas_grayscale: texture_2d<f32>;
@@ -280,7 +285,7 @@ fn vs_cell_text(
 
     let world_pos = cell_pos + size * corner + offset + uniforms.grid_padding.xy;
 
-    let is_cursor_glyph = (instance.atlas_and_flags & 0xFF00u) != 0u;
+    let is_cursor_glyph = (instance.atlas_and_flags & CURSOR_GLYPH_FLAGS_MASK) != 0u;
     let at_cursor = uniforms.cursor_visible != 0u
                  && instance.grid_pos.x == uniforms.cursor_pos.x
                  && instance.grid_pos.y == uniforms.cursor_pos.y;
@@ -308,8 +313,9 @@ fn vs_cell_text(
     out.tex_coord = vec2<f32>(f32(instance.glyph_pos.x), f32(instance.glyph_pos.y))
                   + vec2<f32>(f32(instance.glyph_size.x), f32(instance.glyph_size.y)) * corner;
     out.color = color;
-    out.atlas = instance.atlas_and_flags & 0xFFu;
+    out.atlas = instance.atlas_and_flags & ATLAS_MASK;
     out.bg_color = effective_bg;
+    out.min_contrast = instance.atlas_and_flags & MIN_CONTRAST_FLAG;
 
     return out;
 }
@@ -321,7 +327,10 @@ fn fs_cell_text(in: CellTextOut) -> @location(0) vec4<f32> {
         let uv = in.tex_coord / gs_size;
         let a = textureSample(atlas_grayscale, atlas_sampler, uv).r;
 
-        let fg = apply_min_contrast(in.color.rgb, in.bg_color, uniforms.min_contrast);
+        var fg = in.color.rgb;
+        if in.min_contrast != 0u {
+            fg = apply_min_contrast(fg, in.bg_color, uniforms.min_contrast);
+        }
 
         let alpha = a * in.color.a;
         return vec4<f32>(fg * alpha, alpha);

--- a/crates/seance-render/src/text/cell_builder.rs
+++ b/crates/seance-render/src/text/cell_builder.rs
@@ -39,6 +39,8 @@ pub struct CellText {
 
 const _: () = assert!(size_of::<CellText>() == 32);
 
+const TEXT_FLAG_MIN_CONTRAST: u32 = 1 << 16;
+
 pub struct FrameInfo {
     pub cell_width: f32,
     pub cell_height: f32,
@@ -85,6 +87,7 @@ struct CellSlot {
     byte_offset: u32,
     col: u16,
     fg: [u8; 4],
+    min_contrast: bool,
 }
 
 /// A contiguous group of cells on the same row sharing one [`FontAttrs`],
@@ -114,11 +117,12 @@ impl ShapeRun {
         }
     }
 
-    fn push_cell(&mut self, col: u16, fg: [u8; 4], text: &str) {
+    fn push_cell(&mut self, col: u16, fg: [u8; 4], min_contrast: bool, text: &str) {
         self.slots.push(CellSlot {
             byte_offset: self.text.len() as u32,
             col,
             fg,
+            min_contrast,
         });
         self.text.push_str(text);
     }
@@ -371,13 +375,17 @@ fn shape_runs(
                 continue;
             };
             let slot = run.slot_for_cluster(glyph.cluster);
+            let mut atlas_and_flags = u32::from(entry.is_color);
+            if slot.min_contrast {
+                atlas_and_flags |= TEXT_FLAG_MIN_CONTRAST;
+            }
             out.push(CellText {
                 glyph_pos: entry.pos,
                 glyph_size: entry.size,
                 bearings: [entry.bearing_x as i16, entry.bearing_y as i16],
                 grid_pos: [slot.col, run.row],
                 color: slot.fg,
-                atlas_and_flags: u32::from(entry.is_color),
+                atlas_and_flags,
             });
         }
     }
@@ -454,6 +462,7 @@ impl CellVisitor for RunBuilder<'_> {
         let idx = row as usize * self.cols as usize + col as usize;
 
         let theme_bg = [self.theme.bg[0], self.theme.bg[1], self.theme.bg[2]];
+        let min_contrast = matches!(view.fg, CellColor::Default) && !view.attrs.inverse;
         let mut fg_rgb = resolve_color(self.theme, &view.fg).unwrap_or(self.theme.fg);
         let mut bg_rgb = resolve_color(self.theme, &view.bg).unwrap_or(theme_bg);
         if view.attrs.inverse {
@@ -489,7 +498,7 @@ impl CellVisitor for RunBuilder<'_> {
         self.open
             .as_mut()
             .expect("open run set above")
-            .push_cell(col, fg, view.text);
+            .push_cell(col, fg, min_contrast, view.text);
     }
 }
 
@@ -752,6 +761,30 @@ mod tests {
     }
 
     #[test]
+    fn walk_grid_into_runs_marks_only_default_fg_for_min_contrast() {
+        let theme = Theme::blank();
+        let cells = [
+            ("d", CellColor::Default, CellColor::Default, plain()),
+            ("p", CellColor::Palette(1), CellColor::Default, plain()),
+            ("r", CellColor::Rgb(10, 20, 30), CellColor::Default, plain()),
+            (
+                "i",
+                CellColor::Default,
+                CellColor::Palette(2),
+                CellAttrs {
+                    inverse: true,
+                    ..CellAttrs::default()
+                },
+            ),
+        ];
+        let (_bg, runs) = collect_runs(4, 1, &cells, &theme);
+
+        assert_eq!(runs.len(), 1);
+        let flags: Vec<bool> = runs[0].slots.iter().map(|s| s.min_contrast).collect();
+        assert_eq!(flags, vec![true, false, false, false]);
+    }
+
+    #[test]
     fn walk_grid_into_runs_swaps_fg_and_bg_for_inverse_cells() {
         let theme = Theme::blank();
         let cells = [(
@@ -880,9 +913,9 @@ mod tests {
         // Three cells "a", "é" (2 bytes), "b" → text "aéb",
         // slots at byte_offset [0, 1, 3].
         let mut run = ShapeRun::new(0, FontAttrs::default());
-        run.push_cell(0, [1, 1, 1, 255], "a");
-        run.push_cell(1, [2, 2, 2, 255], "é");
-        run.push_cell(2, [3, 3, 3, 255], "b");
+        run.push_cell(0, [1, 1, 1, 255], true, "a");
+        run.push_cell(1, [2, 2, 2, 255], true, "é");
+        run.push_cell(2, [3, 3, 3, 255], true, "b");
 
         assert_eq!(run.slot_for_cluster(0).col, 0);
         assert_eq!(run.slot_for_cluster(1).col, 1);
@@ -1034,6 +1067,27 @@ mod tests {
         builder.build_frame(&mut source, &mut backend, build_config(&theme));
         let cols: Vec<u16> = builder.text_cells().iter().map(|c| c.grid_pos[0]).collect();
         assert_eq!(cols, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn min_contrast_flag_only_set_for_default_foreground_glyphs() {
+        let theme = Theme::blank();
+        let cells = [
+            ("D", CellColor::Default, CellColor::Default, plain()),
+            ("P", CellColor::Palette(1), CellColor::Default, plain()),
+            ("R", CellColor::Rgb(10, 20, 30), CellColor::Default, plain()),
+        ];
+        let mut source = FakeFrame::new(3, 1, &cells);
+        let mut backend = distributing_backend();
+        let mut builder = CellBuilder::new();
+
+        builder.build_frame(&mut source, &mut backend, build_config(&theme));
+        let flags: Vec<bool> = builder
+            .text_cells()
+            .iter()
+            .map(|c| c.atlas_and_flags & TEXT_FLAG_MIN_CONTRAST != 0)
+            .collect();
+        assert_eq!(flags, vec![true, false, false]);
     }
 
     /// Backend that returns a single ligature glyph at cluster 0 for "==".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,14 +165,14 @@ seance-render-test -> seance-vt, seance-protocol, seance-frame
 
 ### CellText instance layout (matches WGSL, 32 bytes)
 
-| Offset | Field             | Type    | Purpose                                                        |
-| ------ | ----------------- | ------- | -------------------------------------------------------------- |
-| 0      | `glyph_pos`       | `u32×2` | atlas pixel coords                                             |
-| 8      | `glyph_size`      | `u32×2` | bitmap dimensions                                              |
-| 16     | `bearings`        | `i16×2` | x/y bearing                                                    |
-| 20     | `grid_pos`        | `u16×2` | column, row                                                    |
-| 24     | `color`           | `u8×4`  | RGBA foreground (Unorm8x4)                                     |
-| 28     | `atlas_and_flags` | `u32`   | low byte: atlas (0=gray,1=color); byte 1: flags (bit 0=cursor) |
+| Offset | Field             | Type    | Purpose                                                                            |
+| ------ | ----------------- | ------- | ---------------------------------------------------------------------------------- |
+| 0      | `glyph_pos`       | `u32×2` | atlas pixel coords                                                                 |
+| 8      | `glyph_size`      | `u32×2` | bitmap dimensions                                                                  |
+| 16     | `bearings`        | `i16×2` | x/y bearing                                                                        |
+| 20     | `grid_pos`        | `u16×2` | column, row                                                                        |
+| 24     | `color`           | `u8×4`  | RGBA foreground (Unorm8x4)                                                         |
+| 28     | `atlas_and_flags` | `u32`   | low byte: atlas (0=gray,1=color); byte 1: cursor flags; byte 2 bit 0: min-contrast |
 
 ---
 
@@ -312,7 +312,7 @@ palette.
 family = "JetBrainsMono Nerd Font"
 size = 14.0
 features = ["calt"]
-min_contrast = 1.1
+min_contrast = 1.0
 adjust_cell_height = 1.20
 
 [window]


### PR DESCRIPTION
This prevents min-contrast from rewriting app-selected palette/RGB colors, which made low-contrast decorative glyphs like Neovim indent guides look like bar cursors on cursor-line backgrounds.

The default is now 1.0 so fresh configs preserve app colors. When users opt into min-contrast, only default foreground glyphs carry the shader flag; explicit colors bypass adjustment.

Tests run:
- cargo fmt --all
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- npx --yes prettier --check "**/*.md"
- npx --yes markdownlint-cli2 "**/*.md"

No tracked issue.