### PR TITLE
feat(app): tmux-style word/line selection with flash-copy

### DIFF
--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -141,6 +141,22 @@ impl App {
         }
     }
 
+    /// Clear a flashed selection once its deadline has passed.
+    fn step_selection_flash(&mut self) {
+        let Some(surface) = self.surface.as_mut() else {
+            return;
+        };
+        if let Some(deadline) = surface.selection_dismiss_at
+            && Instant::now() >= deadline
+        {
+            surface.selection_dismiss_at = None;
+            if surface.has_selection() {
+                surface.clear_selection();
+            }
+            surface.mark_dirty();
+        }
+    }
+
     /// Earliest instant at which any animation source needs the next
     /// wake. `None` means the terminal is idle — `about_to_wait` will
     /// drop into `ControlFlow::Wait` and the OS suspends us until either
@@ -152,10 +168,15 @@ impl App {
         if surface.occluded {
             return None;
         }
-        if self.config.cursor.blink {
-            Some(surface.last_blink_edge + BLINK_HALF_PERIOD)
-        } else {
-            None
+        let blink = self
+            .config
+            .cursor
+            .blink
+            .then(|| surface.last_blink_edge + BLINK_HALF_PERIOD);
+        match (blink, surface.selection_dismiss_at) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(d), None) | (None, Some(d)) => Some(d),
+            (None, None) => None,
         }
     }
 }
@@ -340,6 +361,7 @@ impl ApplicationHandler<UserEvent> for App {
             return;
         }
         self.step_blink();
+        self.step_selection_flash();
         if let Some(surface) = self.surface.as_ref()
             && surface.content_dirty
             && !surface.occluded

--- a/crates/seance-app/src/events.rs
+++ b/crates/seance-app/src/events.rs
@@ -1,10 +1,13 @@
 //! Winit event handlers that live on `App`. Split out from `app.rs` to keep
 //! the main file focused on lifecycle and frame loop.
 
+use std::time::Duration;
+
 use bytes::Bytes;
 use winit::dpi::PhysicalPosition;
 use winit::event::{ElementState, MouseButton};
 use winit::event_loop::ActiveEventLoop;
+use winit::keyboard::{Key, NamedKey};
 
 use seance_input::{MouseAction, MouseEventInput, VtInput};
 
@@ -15,6 +18,10 @@ use crate::surface_state::SurfaceState;
 
 const FONT_SIZE_MIN: f32 = 6.0;
 const FONT_SIZE_MAX: f32 = 72.0;
+
+/// Duration of the post-copy flash overlay. Long enough to register
+/// visually as a confirmation, short enough to feel instantaneous.
+const SELECTION_FLASH: Duration = Duration::from_millis(150);
 
 impl App {
     pub(crate) fn on_keyboard_input(
@@ -43,6 +50,19 @@ impl App {
                 surface.mark_dirty();
             }
             self.execute_app_command(event_loop, cmd);
+            return;
+        }
+
+        // Bare Enter on an active local selection: copy + flash + dismiss
+        // instead of forwarding to the PTY. Modified Enter (Ctrl/Shift/etc.)
+        // still forwards normally so existing shortcuts keep working.
+        if event.state == ElementState::Pressed
+            && matches!(event.logical_key, Key::Named(NamedKey::Enter))
+            && modifiers.state().is_empty()
+            && let Some(surface) = self.surface_mut()
+            && surface.has_selection()
+        {
+            surface.flash_copy_selection(SELECTION_FLASH);
             return;
         }
 
@@ -231,11 +251,24 @@ fn handle_mouse_press(surface: &mut SurfaceState) {
         .pixel_to_grid(surface.mouse.cursor_pos.x, surface.mouse.cursor_pos.y);
     let clicks = surface.mouse.register_click(col, row);
     match clicks {
-        1 => surface.start_selection(col, row),
-        2 => surface.start_word_selection(col, row),
-        3 => surface.start_line_selection(row),
+        1 => {
+            // A new single click invalidates any pending flash dismissal
+            // — the user is starting a fresh selection gesture.
+            surface.cancel_flash_dismiss();
+            surface.start_selection(col, row);
+            surface.mouse.is_down = true;
+        }
+        2 => {
+            surface.start_word_selection(col, row);
+            // Don't enter drag mode: a follow-up motion shouldn't extend
+            // the flashed word selection.
+            surface.flash_copy_selection(SELECTION_FLASH);
+        }
+        3 => {
+            surface.start_line_selection(row);
+            surface.flash_copy_selection(SELECTION_FLASH);
+        }
         _ => {}
     }
-    surface.mouse.is_down = true;
     surface.mark_dirty();
 }

--- a/crates/seance-app/src/surface_state.rs
+++ b/crates/seance-app/src/surface_state.rs
@@ -6,7 +6,7 @@
 //! future mux domain (`Window -> Tab -> SplitTree`).
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use bytes::{Bytes, BytesMut};
 use winit::dpi::PhysicalSize;
@@ -35,6 +35,10 @@ pub(crate) struct SurfaceState {
     pub(crate) blink_on: bool,
     pub(crate) last_blink_edge: Instant,
     pub(crate) last_vt_cursor_shape: Option<MuxCursorShape>,
+    /// When set, the active selection should be cleared once `Instant::now()`
+    /// reaches this deadline. Drives the brief "flash" overlay shown after
+    /// double/triple-click and Enter-copies operations.
+    pub(crate) selection_dismiss_at: Option<Instant>,
 }
 
 impl SurfaceState {
@@ -60,6 +64,7 @@ impl SurfaceState {
             blink_on: true,
             last_blink_edge: Instant::now(),
             last_vt_cursor_shape: None,
+            selection_dismiss_at: None,
         }
     }
 
@@ -197,6 +202,25 @@ impl SurfaceState {
         if let Ok(mut cb) = arboard::Clipboard::new() {
             let _ = cb.set_text(text);
         }
+    }
+
+    /// Copy the current selection to the clipboard and arm a deferred
+    /// dismiss `delay` from now. The selection stays painted during the
+    /// flash window so the user gets a visible confirmation that the
+    /// copy happened, then `App` clears it on the next animation tick.
+    pub(crate) fn flash_copy_selection(&mut self, delay: Duration) {
+        if !self.has_selection() {
+            return;
+        }
+        self.copy_selection_to_clipboard();
+        self.selection_dismiss_at = Some(Instant::now() + delay);
+        self.mark_dirty();
+    }
+
+    /// Clear the deferred-dismiss state without touching the selection.
+    /// Called when the user starts a new selection during the flash.
+    pub(crate) fn cancel_flash_dismiss(&mut self) {
+        self.selection_dismiss_at = None;
     }
 
     pub(crate) fn refresh_hovered_link(&mut self) {

--- a/crates/seance-config/src/theme/mod.rs
+++ b/crates/seance-config/src/theme/mod.rs
@@ -47,13 +47,24 @@ impl Theme {
     /// fails. Not exposed via `Default` because production code should
     /// always route through [`load`].
     pub fn blank() -> Self {
+        // tmux-style inverse: opaque selection bg painted with the
+        // theme's foreground, and glyphs drawn with the theme bg. The
+        // alpha-1.0 here is authoritative — the renderer paints the
+        // selection bg as a straight replace, not an alpha blend.
+        let bg = [0u8, 0, 0];
+        let fg = [200u8, 200, 200];
         Self {
-            bg: [0, 0, 0, 255],
-            fg: [200, 200, 200],
+            bg: [bg[0], bg[1], bg[2], 255],
+            fg,
             cursor: [200, 200, 200, 255],
             cursor_text: None,
-            selection_bg: [0.3, 0.5, 0.8, 0.4],
-            selection_fg: None,
+            selection_bg: [
+                f32::from(fg[0]) / 255.0,
+                f32::from(fg[1]) / 255.0,
+                f32::from(fg[2]) / 255.0,
+                1.0,
+            ],
+            selection_fg: Some(bg),
             palette: default_xterm_palette(),
         }
     }

--- a/crates/seance-config/src/theme/parser.rs
+++ b/crates/seance-config/src/theme/parser.rs
@@ -87,7 +87,7 @@ pub fn parse_source(text: &str) -> Result<Theme, ParseError> {
             "cursor-color" => theme.cursor = rgba(parse_color(value, line_no)?),
             "cursor-text" => theme.cursor_text = Some(parse_color(value, line_no)?),
             "selection-background" => {
-                theme.selection_bg = rgba_f32(parse_color(value, line_no)?, 0.4);
+                theme.selection_bg = rgba_f32(parse_color(value, line_no)?, 1.0);
             }
             "selection-foreground" => theme.selection_fg = Some(parse_color(value, line_no)?),
             // Ghostty accepts these but they never appear in bundled files
@@ -214,8 +214,8 @@ mod tests {
         assert!(t.selection_fg.is_some());
         assert_eq!(t.selection_fg.unwrap(), [0xff, 0xee, 0xdd]);
         assert_eq!(t.cursor_text, Some([0x01, 0x02, 0x03]));
-        // alpha on selection stays at the hardcoded 0.4 blend default.
-        assert!((t.selection_bg[3] - 0.4).abs() < 1e-6);
+        // Selection bg is painted opaque (tmux-style inverse), not alpha-blended.
+        assert!((t.selection_bg[3] - 1.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/seance-mux/src/interaction.rs
+++ b/crates/seance-mux/src/interaction.rs
@@ -63,11 +63,18 @@ impl PaneInteractionState {
     }
 
     pub fn start_word_selection(&mut self, col: u16, row: u16) {
-        self.selection = Some(Selection::new_word(GridPos { col, row }));
+        self.selection = Some(Selection::new(GridPos { col, row }));
     }
 
     pub fn start_line_selection(&mut self, row: u16) {
         self.selection = Some(Selection::new_line(GridPos { col: 0, row }));
+    }
+
+    /// Replace the active selection with `selection`. Used when callers
+    /// (e.g. `PaneView`) have resolved a multi-cell range against the
+    /// current snapshot and want to install it directly.
+    pub fn set_selection(&mut self, selection: Selection) {
+        self.selection = Some(selection);
     }
 
     pub fn update_selection(&mut self, col: u16, row: u16) {

--- a/crates/seance-mux/src/pane_view.rs
+++ b/crates/seance-mux/src/pane_view.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use seance_frame::SnapshotFrameSource;
 use seance_protocol::frame::{
-    CursorShape, DirtySnapshot, FrameDelta, GridPos, HyperlinkRun, TerminalModes, VtSnapshot,
-    apply_frame_delta,
+    CursorShape, DirtySnapshot, FrameDelta, GridPos, HyperlinkRun, Selection, TerminalModes,
+    VtSnapshot, apply_frame_delta,
 };
 use seance_protocol::identity::{PaneRef, ServerSeq};
 use seance_protocol::mux::PaneUpdate;
@@ -117,11 +117,36 @@ impl PaneView {
     }
 
     pub fn start_word_selection(&mut self, col: u16, row: u16) {
-        self.interaction.start_word_selection(col, row);
+        // Resolve the word range against the latest snapshot. If the
+        // snapshot is missing or the click landed on whitespace, fall
+        // back to a single-cell character selection so the click never
+        // disappears silently.
+        let resolved = self
+            .latest_snapshot
+            .as_ref()
+            .and_then(|snap| snap.word_range_at(row, col));
+        if let Some((start, end)) = resolved {
+            self.interaction
+                .set_selection(Selection::word_range(start, end));
+        } else {
+            self.interaction.start_selection(col, row);
+        }
     }
 
     pub fn start_line_selection(&mut self, row: u16) {
-        self.interaction.start_line_selection(row);
+        if let Some(snap) = self.latest_snapshot.as_ref() {
+            let (first, last) = snap.wrap_chain(row);
+            let last_col = snap.cols.saturating_sub(1);
+            self.interaction.set_selection(Selection::line_range(
+                GridPos { col: 0, row: first },
+                GridPos {
+                    col: last_col,
+                    row: last,
+                },
+            ));
+        } else {
+            self.interaction.start_line_selection(row);
+        }
     }
 
     pub fn update_selection(&mut self, col: u16, row: u16) {
@@ -166,5 +191,93 @@ impl PaneView {
         } else {
             Err(PaneError::new("message routed to a different pane"))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use seance_protocol::frame::{
+        CellAttrs, CellColor, FrameDelta, RowMeta, SelectionGranularity, VtSnapshot,
+    };
+    use seance_protocol::identity::{PaneRef, ServerSeq};
+    use seance_protocol::mux::PaneUpdate;
+
+    fn snapshot_with(cols: u16, rows: u16, cells: &[&str]) -> VtSnapshot {
+        let mut snap = VtSnapshot::empty(cols, rows);
+        snap.generation = 1;
+        for text in cells {
+            snap.push_cell(
+                text,
+                CellColor::Default,
+                CellColor::Default,
+                CellAttrs::default(),
+            );
+        }
+        snap
+    }
+
+    fn install_snapshot(snap: VtSnapshot) -> PaneView {
+        let mut view = PaneView::new(PaneRef::LOCAL);
+        view.apply_update(&PaneUpdate {
+            pane: PaneRef::LOCAL,
+            seq: ServerSeq(1),
+            image_events: Vec::new(),
+            frame: Some(FrameDelta::Full {
+                generation: snap.generation,
+                snapshot: snap,
+            }),
+        })
+        .unwrap();
+        view
+    }
+
+    #[test]
+    fn start_word_selection_resolves_word_range_from_snapshot() {
+        let snap = snapshot_with(6, 1, &["f", "o", "o", " ", "b", "r"]);
+        let mut view = install_snapshot(snap);
+        view.start_word_selection(1, 0);
+        let (s, e) = view.selection_range().unwrap();
+        assert_eq!((s.col, e.col), (0, 2));
+        assert_eq!(view.selection_text().as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn start_word_selection_on_whitespace_falls_back_to_single_cell() {
+        let snap = snapshot_with(3, 1, &["a", " ", "b"]);
+        let mut view = install_snapshot(snap);
+        view.start_word_selection(1, 0);
+        let (s, e) = view.selection_range().unwrap();
+        assert_eq!((s.col, e.col), (1, 1));
+        // Single-cell character selection of an empty cell yields no text.
+        assert_eq!(view.selection_text(), None);
+    }
+
+    #[test]
+    fn start_line_selection_spans_wrap_chain() {
+        let mut snap = snapshot_with(2, 3, &["a", "b", "c", "d", "e", "f"]);
+        snap.rows_meta[0] = RowMeta {
+            wrap: true,
+            wrap_continuation: false,
+        };
+        snap.rows_meta[1] = RowMeta {
+            wrap: false,
+            wrap_continuation: true,
+        };
+        let mut view = install_snapshot(snap);
+        view.start_line_selection(0);
+        let sel = view.interaction.selection().unwrap();
+        assert_eq!(sel.granularity(), SelectionGranularity::Line);
+        let (s, e) = sel.ordered_range();
+        assert_eq!((s.row, e.row), (0, 1));
+        assert_eq!(view.selection_text().as_deref(), Some("ab\ncd"));
+    }
+
+    #[test]
+    fn start_line_selection_without_snapshot_falls_back_to_single_row() {
+        let mut view = PaneView::new(PaneRef::LOCAL);
+        view.start_line_selection(2);
+        let sel = view.interaction.selection().unwrap();
+        assert_eq!(sel.granularity(), SelectionGranularity::Line);
     }
 }

--- a/crates/seance-protocol/src/frame.rs
+++ b/crates/seance-protocol/src/frame.rs
@@ -41,12 +41,29 @@ impl Selection {
         Self::at(pos, SelectionGranularity::Character)
     }
 
-    pub fn new_word(pos: GridPos) -> Self {
-        Self::at(pos, SelectionGranularity::Word)
-    }
-
     pub fn new_line(pos: GridPos) -> Self {
         Self::at(pos, SelectionGranularity::Line)
+    }
+
+    /// Word selection spanning a precomputed `(start, end)` pair. Both
+    /// endpoints must already point at the inclusive boundaries of the
+    /// word; rendering uses them verbatim.
+    pub fn word_range(start: GridPos, end: GridPos) -> Self {
+        Self {
+            anchor: start,
+            head: end,
+            granularity: SelectionGranularity::Word,
+        }
+    }
+
+    /// Line selection spanning a precomputed `(start, end)` pair, used
+    /// for wrap-aware logical lines.
+    pub fn line_range(start: GridPos, end: GridPos) -> Self {
+        Self {
+            anchor: start,
+            head: end,
+            granularity: SelectionGranularity::Line,
+        }
     }
 
     fn at(pos: GridPos, granularity: SelectionGranularity) -> Self {
@@ -222,6 +239,61 @@ impl VtSnapshot {
             images: Vec::new(),
             hyperlinks: Vec::new(),
         }
+    }
+
+    /// Inclusive `(start, end)` range of the word containing `(row, col)`.
+    /// Returns `None` if the cell is empty/whitespace, or out of bounds.
+    /// A "word" extends across consecutive cells whose text contains at
+    /// least one [`is_word_char`] character — covers identifiers, paths,
+    /// and URLs while breaking on whitespace and most punctuation.
+    pub fn word_range_at(&self, row: u16, col: u16) -> Option<(GridPos, GridPos)> {
+        if row >= self.rows || col >= self.cols {
+            return None;
+        }
+        if !self.cell_is_word(row, col) {
+            return None;
+        }
+        let mut start = col;
+        while start > 0 && self.cell_is_word(row, start - 1) {
+            start -= 1;
+        }
+        let mut end = col;
+        while end + 1 < self.cols && self.cell_is_word(row, end + 1) {
+            end += 1;
+        }
+        Some((GridPos { col: start, row }, GridPos { col: end, row }))
+    }
+
+    fn cell_is_word(&self, row: u16, col: u16) -> bool {
+        let Some(cell) = self.cell_at(row, col) else {
+            return false;
+        };
+        let text = self.cell_text(cell);
+        text.chars().any(is_word_char)
+    }
+
+    /// Inclusive row range of the wrap chain containing `row` — i.e. the
+    /// rows that together form one logical (possibly soft-wrapped) line.
+    /// Walks up while the previous row is a wrap continuation, then down
+    /// while the current row's `wrap` flag is set.
+    pub fn wrap_chain(&self, row: u16) -> (u16, u16) {
+        if row >= self.rows || self.rows == 0 {
+            return (row, row);
+        }
+        let mut start = row;
+        while start > 0
+            && self
+                .rows_meta
+                .get(usize::from(start))
+                .is_some_and(|m| m.wrap_continuation)
+        {
+            start -= 1;
+        }
+        let mut end = row;
+        while end + 1 < self.rows && self.rows_meta.get(usize::from(end)).is_some_and(|m| m.wrap) {
+            end += 1;
+        }
+        (start, end)
     }
 
     pub fn cell_text(&self, cell: &SnapshotCell) -> &str {
@@ -819,6 +891,21 @@ pub fn apply_frame_delta(
     }
 }
 
+/// Returns true for characters that should be treated as part of a
+/// "word" by double-click selection. Includes Unicode alphanumerics
+/// plus a small set of identifier/path/URL punctuation. Approximates
+/// tmux's default word-separators behaviour while staying useful for
+/// paths and URLs. A future PR may expose this via config.
+fn is_word_char(c: char) -> bool {
+    if c.is_alphanumeric() {
+        return true;
+    }
+    matches!(
+        c,
+        '-' | '_' | '.' | '/' | '~' | '+' | '@' | ':' | '?' | '#' | '%' | '&' | '='
+    )
+}
+
 fn column_range(
     granularity: SelectionGranularity,
     row_idx: u16,
@@ -1267,6 +1354,79 @@ mod tests {
         assert_eq!(applied.cell_hyperlink(cell), Some("https://example.com/x"));
         let other = applied.cell_at(0, 1).unwrap();
         assert_eq!(applied.cell_hyperlink(other), None);
+    }
+
+    #[test]
+    fn word_range_at_expands_across_word_chars_only() {
+        // "hello world/path one"
+        let snap = snapshot(
+            20,
+            1,
+            1,
+            &[
+                "h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d", "/", "p", "a", "t", "h",
+                " ", "o", "n", "e",
+            ],
+        );
+        // Click inside "hello".
+        let (s, e) = snap.word_range_at(0, 2).unwrap();
+        assert_eq!((s.col, e.col), (0, 4));
+        // Click on the trailing 'o' of hello.
+        let (s, e) = snap.word_range_at(0, 4).unwrap();
+        assert_eq!((s.col, e.col), (0, 4));
+        // Click on space → None.
+        assert!(snap.word_range_at(0, 5).is_none());
+        // Click inside "world/path" — the slash is part of the word class.
+        let (s, e) = snap.word_range_at(0, 9).unwrap();
+        assert_eq!((s.col, e.col), (6, 15));
+        // Click on the slash itself — still part of the word.
+        let (s, e) = snap.word_range_at(0, 11).unwrap();
+        assert_eq!((s.col, e.col), (6, 15));
+        // Last word reaches the row's end.
+        let (s, e) = snap.word_range_at(0, 18).unwrap();
+        assert_eq!((s.col, e.col), (17, 19));
+        // Out-of-bounds row → None.
+        assert!(snap.word_range_at(5, 0).is_none());
+    }
+
+    #[test]
+    fn wrap_chain_walks_continuation_metadata_in_both_directions() {
+        let mut snap = snapshot(1, 4, 1, &["a", "b", "c", "d"]);
+        // Rows 0–2 form one logical line; row 3 is its own line.
+        snap.rows_meta[0] = RowMeta {
+            wrap: true,
+            wrap_continuation: false,
+        };
+        snap.rows_meta[1] = RowMeta {
+            wrap: true,
+            wrap_continuation: true,
+        };
+        snap.rows_meta[2] = RowMeta {
+            wrap: false,
+            wrap_continuation: true,
+        };
+        snap.rows_meta[3] = RowMeta::default();
+
+        assert_eq!(snap.wrap_chain(0), (0, 2));
+        assert_eq!(snap.wrap_chain(1), (0, 2));
+        assert_eq!(snap.wrap_chain(2), (0, 2));
+        assert_eq!(snap.wrap_chain(3), (3, 3));
+    }
+
+    #[test]
+    fn line_range_selection_spans_wrap_chain() {
+        let mut snap = snapshot(2, 3, 1, &["a", "b", "c", "d", "e", "f"]);
+        snap.rows_meta[0] = RowMeta {
+            wrap: true,
+            wrap_continuation: false,
+        };
+        snap.rows_meta[1] = RowMeta {
+            wrap: false,
+            wrap_continuation: true,
+        };
+        snap.rows_meta[2] = RowMeta::default();
+        let sel = Selection::line_range(GridPos { col: 0, row: 0 }, GridPos { col: 1, row: 1 });
+        assert_eq!(snap.selection_text(&sel).as_deref(), Some("ab\ncd"));
     }
 
     #[test]

--- a/crates/seance-render/src/gpu/shaders/cell.wgsl
+++ b/crates/seance-render/src/gpu/shaders/cell.wgsl
@@ -22,6 +22,10 @@ struct Uniforms {
     selection_start: vec2<u32>,
     selection_end: vec2<u32>,
     selection_color: vec4<f32>,
+    // alpha == 0 means "no override"; glyphs in selection then fall
+    // back to the cell's effective bg for natural contrast against
+    // selection_color.
+    selection_fg: vec4<f32>,
     selection_active: u32,
     baseline: f32,
     hovered_link_active: u32,
@@ -194,10 +198,9 @@ fn fs_cell_bg(in: FullScreenOut) -> @location(0) vec4<f32> {
 
     if is_in_selection(col, row) {
         let sel = uniforms.selection_color;
-        color = vec4<f32>(
-            mix(color.rgb, sel.rgb, sel.a),
-            max(color.a, sel.a),
-        );
+        // Tmux-style: paint the cell bg fully opaque so glyphs sit on a
+        // solid block instead of an alpha tint.
+        color = vec4<f32>(sel.rgb, 1.0);
     }
 
     if uniforms.cursor_visible != 0u
@@ -299,7 +302,17 @@ fn vs_cell_text(
     let effective_bg = select(bg_srgb.rgb, uniforms.bg_color.rgb, bg_srgb.a < 0.01);
 
     var color = instance.color;
-    if (at_cursor || at_cursor_wide) && !is_cursor_glyph {
+    if is_in_selection(instance.grid_pos.x, instance.grid_pos.y) {
+        // Selection wins over cursor inversion. Use the explicit
+        // selection_fg if the theme provides one (alpha != 0); else
+        // fall back to the cell's effective bg for contrast against the
+        // (now opaque) selection bg.
+        if uniforms.selection_fg.a > 0.0 {
+            color = vec4<f32>(uniforms.selection_fg.rgb, color.a);
+        } else {
+            color = vec4<f32>(effective_bg, color.a);
+        }
+    } else if (at_cursor || at_cursor_wide) && !is_cursor_glyph {
         if uniforms.overlay_shape == 1u {
             // Block cursor fills the cell; invert glyph to bg for legibility.
             color = vec4<f32>(effective_bg, color.a);

--- a/crates/seance-render/src/gpu/shaders/image.wgsl
+++ b/crates/seance-render/src/gpu/shaders/image.wgsl
@@ -20,6 +20,7 @@ struct Uniforms {
     selection_start: vec2<u32>,
     selection_end: vec2<u32>,
     selection_color: vec4<f32>,
+    selection_fg: vec4<f32>,
     selection_active: u32,
     baseline: f32,
     hovered_link_active: u32,

--- a/crates/seance-render/src/gpu/uniforms.rs
+++ b/crates/seance-render/src/gpu/uniforms.rs
@@ -34,7 +34,7 @@ impl From<ProtocolCursorShape> for CursorShape {
 }
 
 /// Layout must match the `Uniforms` struct in `cell.wgsl` exactly.
-const _: () = assert!(size_of::<Uniforms>() == 256);
+const _: () = assert!(size_of::<Uniforms>() == 272);
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
@@ -55,6 +55,10 @@ pub(crate) struct Uniforms {
     pub selection_start: [u32; 2],
     pub selection_end: [u32; 2],
     pub selection_color: [f32; 4],
+    /// RGBA selection foreground. `a == 0` is the sentinel for "no
+    /// override" — glyphs inside the selection then fall back to their
+    /// effective bg, which gives natural contrast against `selection_color`.
+    pub selection_fg: [f32; 4],
     pub selection_active: u32,
     pub baseline: f32,
     pub hovered_link_active: u32,
@@ -113,6 +117,16 @@ impl Uniforms {
             selection_start: sel_start,
             selection_end: sel_end,
             selection_color: theme.selection_bg,
+            selection_fg: match theme.selection_fg {
+                Some([r, g, b]) => [
+                    f32::from(r) / 255.0,
+                    f32::from(g) / 255.0,
+                    f32::from(b) / 255.0,
+                    1.0,
+                ],
+                // alpha=0 sentinel → wgsl falls back to cell bg.
+                None => [0.0, 0.0, 0.0, 0.0],
+            },
             selection_active: sel_active,
             baseline: fi.baseline,
             hovered_link_active: link_active,


### PR DESCRIPTION
Double-click selects a word, triple-click selects a wrap-aware logical line, each followed by a brief overlay flash that copies to the clipboard and then dismisses the selection. Bare Enter on an active local selection now copies + dismisses instead of forwarding to the PTY (modified Enter still forwards).

Word ranges expand across cells whose text contains Unicode alphanumerics or one of `-_./~+@:?#%&=`, approximating tmux's default word-separators while staying useful for paths and URLs. Wrap-aware line selection walks `RowMeta::wrap` / `wrap_continuation` in both directions, so a soft-wrapped command line copies as one logical line.

The selection overlay is now opaque tmux-style inverse instead of a 40%-alpha tint: `selection_bg` paints the cell bg fully, and glyphs inside the selection switch to `selection_fg` (falling back to the cell's effective bg when the theme provides no explicit fg) so contrast is preserved automatically. `selection_fg` is plumbed through the shared `Uniforms` block; `image.wgsl` mirrors the layout to keep wgsl validation in sync.

A 150 ms flash gives a visible confirmation that the copy happened; `App`'s deadline scheduler merges the flash deadline with the blink deadline so an idle terminal still parks the event loop.

Out of scope, deferred to follow-ups: configurable word-separators, dragging to extend an existing word/line selection (drag remains character-granularity), copy-mode / keyboard-driven selection, and selection-aware mouse-tracking interactions beyond the existing Shift-to-override behaviour.

No tracked issue.