### PR TITLE
feat(vt): OSC 52 clipboard read/write with policy gating

### DIFF
--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -280,17 +280,27 @@ impl ApplicationHandler<UserEvent> for App {
             UserEvent::Mux(MuxEvent::Wake) => {
                 let _span = tracing::debug_span!("mux::refresh").entered();
                 let mut should_exit = false;
+                let read_policy = self.config.clipboard.read;
+                let write_policy = self.config.clipboard.write;
                 if let Some(surface) = self.surface_mut() {
                     match surface.refresh_updates() {
                         Ok(refresh) => {
                             let frame_dirty = refresh.frame_dirty;
                             let image_events = refresh.image_events;
                             let exited = refresh.exited;
+                            let clipboard_requests = refresh.clipboard_requests;
                             for image_event in &image_events {
                                 surface.renderer.apply_image_cache_event(image_event);
                             }
                             for err in refresh.errors {
                                 tracing::warn!("pane error: {err}");
+                            }
+                            for (_pane, request) in clipboard_requests {
+                                surface.handle_clipboard_request(
+                                    request,
+                                    read_policy,
+                                    write_policy,
+                                );
                             }
                             if frame_dirty || !image_events.is_empty() {
                                 surface.mark_dirty();

--- a/crates/seance-app/src/surface_state.rs
+++ b/crates/seance-app/src/surface_state.rs
@@ -324,7 +324,7 @@ impl SurfaceState {
                         return;
                     };
                     if let Ok(mut cb) = arboard::Clipboard::new()
-                        && let Err(err) = cb.set_text(text.to_owned())
+                        && let Err(err) = cb.set_text(text)
                     {
                         tracing::warn!("OSC 52 clipboard write failed: {err}");
                     }

--- a/crates/seance-app/src/surface_state.rs
+++ b/crates/seance-app/src/surface_state.rs
@@ -13,9 +13,11 @@ use winit::dpi::PhysicalSize;
 use winit::event::Modifiers;
 use winit::window::{CursorIcon, Window};
 
+use seance_config::ClipboardPolicy;
 use seance_mux::{
-    ClientRefresh, CursorShape as MuxCursorShape, DetectedLink, GridPos, LinkModifiers, LinkTarget,
-    LocalDomain, MuxClient, PaneRef, Resize, TerminalModes, ThemeColors,
+    ClientRefresh, ClipboardRequest, CursorShape as MuxCursorShape, DetectedLink, GridPos,
+    LinkModifiers, LinkTarget, LocalDomain, MuxClient, PaneRef, Resize, TerminalModes, ThemeColors,
+    encode_osc52_reply,
 };
 use seance_render::{HoveredLinkRange, RenderInputs, TerminalRenderer};
 
@@ -299,5 +301,66 @@ impl SurfaceState {
             bytes.extend_from_slice(b"\x1b[201~");
         }
         self.write_to_pty(bytes.freeze());
+    }
+
+    /// Honor an OSC 52 clipboard request from the active pane, gated by the
+    /// user's `clipboard.{read,write}` policy. Writes go directly to the OS
+    /// clipboard; reads round-trip through arboard and produce an OSC 52
+    /// reply that is queued back to the PTY.
+    pub(crate) fn handle_clipboard_request(
+        &mut self,
+        request: ClipboardRequest,
+        read_policy: ClipboardPolicy,
+        write_policy: ClipboardPolicy,
+    ) {
+        match request {
+            ClipboardRequest::Write(data) => match write_policy {
+                ClipboardPolicy::Allow => {
+                    let Ok(text) = std::str::from_utf8(&data) else {
+                        tracing::warn!(
+                            "OSC 52 write payload was not valid UTF-8; dropping {} bytes",
+                            data.len(),
+                        );
+                        return;
+                    };
+                    if let Ok(mut cb) = arboard::Clipboard::new()
+                        && let Err(err) = cb.set_text(text.to_owned())
+                    {
+                        tracing::warn!("OSC 52 clipboard write failed: {err}");
+                    }
+                }
+                ClipboardPolicy::Ask => {
+                    // The confirm-overlay modal lives behind the M3 UI work
+                    // (#6). Until that lands, fall back to deny so an
+                    // unprompted application can't silently rewrite the
+                    // system clipboard.
+                    tracing::info!(
+                        "OSC 52 write denied: clipboard.write = \"ask\" and no prompt UI yet; \
+                         set clipboard.write = \"allow\" in config.toml to permit",
+                    );
+                }
+                ClipboardPolicy::Deny => {
+                    tracing::debug!("OSC 52 write denied by clipboard.write policy");
+                }
+            },
+            ClipboardRequest::Read => match read_policy {
+                ClipboardPolicy::Allow => {
+                    let Ok(mut cb) = arboard::Clipboard::new() else {
+                        return;
+                    };
+                    let text = cb.get_text().unwrap_or_default();
+                    self.write_to_pty(encode_osc52_reply(text.as_bytes()));
+                }
+                ClipboardPolicy::Ask => {
+                    tracing::info!(
+                        "OSC 52 read denied: clipboard.read = \"ask\" and no prompt UI yet; \
+                         set clipboard.read = \"allow\" in config.toml to permit",
+                    );
+                }
+                ClipboardPolicy::Deny => {
+                    tracing::debug!("OSC 52 read denied by clipboard.read policy");
+                }
+            },
+        }
     }
 }

--- a/crates/seance-config/src/lib.rs
+++ b/crates/seance-config/src/lib.rs
@@ -13,7 +13,7 @@ pub mod theme;
 
 pub use diff::ConfigDiff;
 pub use schema::{
-    ClipboardConfig, Config, CursorConfig, CursorStyle, FontConfig, InputConfig,
+    ClipboardConfig, ClipboardPolicy, Config, CursorConfig, CursorStyle, FontConfig, InputConfig,
     LinkModifiersConfig, LinksConfig, MacosOptionAsAlt, MouseConfig, ScrollbackConfig,
     WindowConfig,
 };
@@ -173,10 +173,30 @@ mod tests {
     #[test]
     fn clipboard_defaults_match_spec() {
         let cfg = Config::default();
-        assert!(cfg.clipboard.read);
-        assert!(cfg.clipboard.write);
+        assert_eq!(cfg.clipboard.read, ClipboardPolicy::Ask);
+        assert_eq!(cfg.clipboard.write, ClipboardPolicy::Allow);
         assert!(cfg.clipboard.paste_protection);
         assert!(!cfg.clipboard.copy_on_select);
+    }
+
+    #[test]
+    fn clipboard_policy_parses_each_variant() {
+        for (raw, want) in [
+            ("allow", ClipboardPolicy::Allow),
+            ("ask", ClipboardPolicy::Ask),
+            ("deny", ClipboardPolicy::Deny),
+        ] {
+            let src = format!(
+                r#"
+                [clipboard]
+                read = "{raw}"
+                write = "{raw}"
+                "#,
+            );
+            let cfg: Config = toml::from_str(&src).unwrap();
+            assert_eq!(cfg.clipboard.read, want);
+            assert_eq!(cfg.clipboard.write, want);
+        }
     }
 
     #[test]

--- a/crates/seance-config/src/lib.rs
+++ b/crates/seance-config/src/lib.rs
@@ -173,8 +173,10 @@ mod tests {
     #[test]
     fn clipboard_defaults_match_spec() {
         let cfg = Config::default();
-        assert_eq!(cfg.clipboard.read, ClipboardPolicy::Ask);
-        assert_eq!(cfg.clipboard.write, ClipboardPolicy::Allow);
+        // Both default to deny — users opt in to OSC 52 explicitly. See the
+        // `ClipboardPolicy` doc-comment for the `ask` upgrade path.
+        assert_eq!(cfg.clipboard.read, ClipboardPolicy::Deny);
+        assert_eq!(cfg.clipboard.write, ClipboardPolicy::Deny);
         assert!(cfg.clipboard.paste_protection);
         assert!(!cfg.clipboard.copy_on_select);
     }

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -111,16 +111,19 @@ impl Default for CursorConfig {
 
 /// How OSC 52 clipboard reads/writes are authorized.
 ///
-/// `Ask` is the safe default for `read`: the prompt UI lives behind the
-/// modal-overlay work tracked in epic M3, so until that ships the runtime
-/// treats `Ask` as `Deny` and logs a one-shot hint to flip the config to
-/// `allow` (or wait for the overlay).
+/// The `Ask` variant exists in the wire format so configs can opt in to a
+/// confirm-prompt today and have the runtime upgrade them automatically once
+/// the modal-overlay UI lands (tracked under the M3 clipboard epic, #6).
+/// Until that ships, the runtime treats `Ask` as `Deny` and logs a one-shot
+/// hint pointing users at `allow`.
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ClipboardPolicy {
     Allow,
-    #[default]
     Ask,
+    /// Default: silently refuse OSC 52 traffic. Users opt in to clipboard
+    /// integration explicitly via `clipboard.{read,write} = "allow"`.
+    #[default]
     Deny,
 }
 
@@ -136,8 +139,8 @@ pub struct ClipboardConfig {
 impl Default for ClipboardConfig {
     fn default() -> Self {
         Self {
-            read: ClipboardPolicy::Ask,
-            write: ClipboardPolicy::Allow,
+            read: ClipboardPolicy::Deny,
+            write: ClipboardPolicy::Deny,
             paste_protection: true,
             copy_on_select: false,
         }

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -109,11 +109,26 @@ impl Default for CursorConfig {
     }
 }
 
+/// How OSC 52 clipboard reads/writes are authorized.
+///
+/// `Ask` is the safe default for `read`: the prompt UI lives behind the
+/// modal-overlay work tracked in epic M3, so until that ships the runtime
+/// treats `Ask` as `Deny` and logs a one-shot hint to flip the config to
+/// `allow` (or wait for the overlay).
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ClipboardPolicy {
+    Allow,
+    #[default]
+    Ask,
+    Deny,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ClipboardConfig {
-    pub read: bool,
-    pub write: bool,
+    pub read: ClipboardPolicy,
+    pub write: ClipboardPolicy,
     pub paste_protection: bool,
     pub copy_on_select: bool,
 }
@@ -121,8 +136,8 @@ pub struct ClipboardConfig {
 impl Default for ClipboardConfig {
     fn default() -> Self {
         Self {
-            read: true,
-            write: true,
+            read: ClipboardPolicy::Ask,
+            write: ClipboardPolicy::Allow,
             paste_protection: true,
             copy_on_select: false,
         }

--- a/crates/seance-mux/src/client.rs
+++ b/crates/seance-mux/src/client.rs
@@ -134,6 +134,9 @@ impl<D: Domain> MuxClient<D> {
                 DomainEvent::PaneExited { pane } => {
                     refresh.exited.push(pane);
                 }
+                DomainEvent::ClipboardRequest { pane, request } => {
+                    refresh.clipboard_requests.push((pane, request));
+                }
                 DomainEvent::Error { message, .. } => {
                     refresh.errors.push(message);
                 }

--- a/crates/seance-mux/src/events.rs
+++ b/crates/seance-mux/src/events.rs
@@ -1,6 +1,7 @@
 use seance_protocol::identity::PaneRef;
 use seance_protocol::image_cache::ImageCacheEvent;
 use seance_protocol::mux::PaneUpdate;
+use seance_vt::ClipboardRequest;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MuxEvent {
@@ -14,6 +15,15 @@ pub enum DomainEvent {
     PaneExited {
         pane: PaneRef,
     },
+    /// An OSC 52 clipboard request originating from `pane` was parsed by the
+    /// VT layer. The mux client forwards these unchanged through
+    /// [`ClientRefresh::clipboard_requests`]; arbitration (the
+    /// `clipboard.{read,write}` policy, OS clipboard access) lives in the
+    /// application layer.
+    ClipboardRequest {
+        pane: PaneRef,
+        request: ClipboardRequest,
+    },
     Error {
         pane: Option<PaneRef>,
         message: String,
@@ -26,6 +36,7 @@ pub struct ClientRefresh {
     pub image_events: Vec<ImageCacheEvent>,
     pub exited: Vec<PaneRef>,
     pub errors: Vec<String>,
+    pub clipboard_requests: Vec<(PaneRef, ClipboardRequest)>,
 }
 
 impl ClientRefresh {
@@ -34,5 +45,6 @@ impl ClientRefresh {
             && self.image_events.is_empty()
             && self.exited.is_empty()
             && self.errors.is_empty()
+            && self.clipboard_requests.is_empty()
     }
 }

--- a/crates/seance-mux/src/lib.rs
+++ b/crates/seance-mux/src/lib.rs
@@ -30,6 +30,7 @@ pub use seance_protocol::frame::{
 pub use seance_protocol::identity::{DomainId, ImageId, ImageKey, PaneRef};
 pub use seance_protocol::mux::LineContent;
 pub use seance_protocol::transport::{InProcessTransport, TransportFrame};
+pub use seance_vt::{ClipboardRequest, encode_osc52_reply};
 
 #[cfg(test)]
 mod tests;

--- a/crates/seance-mux/src/local.rs
+++ b/crates/seance-mux/src/local.rs
@@ -11,7 +11,7 @@ use seance_protocol::identity::{
 use seance_protocol::image_cache::{ImageCacheEvent, ImageFormat, ImagePayload};
 use seance_protocol::limits::MAX_RETAINED_PANE_UPDATES;
 use seance_protocol::mux::PaneUpdate;
-use seance_vt::{VtEvent, VtSessionHandle, spawn_vt_session};
+use seance_vt::{ClipboardRequest, VtEvent, VtSessionHandle, spawn_vt_session};
 
 use crate::{
     Domain, DomainEvent, MuxEvent, PaneError, PaneFrameHistory, PaneSpawnOptions, SpawnError,
@@ -69,6 +69,9 @@ impl Domain for LocalDomain {
         let vt = spawn_vt_session(options.into(), move |event| {
             let local_event = match event {
                 VtEvent::ContentDirty => LocalDomainEvent::ContentDirty { pane: pane_ref },
+                VtEvent::ClipboardActivity => {
+                    LocalDomainEvent::ClipboardActivity { pane: pane_ref }
+                }
                 VtEvent::Exited => LocalDomainEvent::Exited { pane: pane_ref },
             };
             let _ = pending_tx.send(local_event);
@@ -83,6 +86,13 @@ impl Domain for LocalDomain {
         while let Ok(event) = self.pending_rx.try_recv() {
             match event {
                 LocalDomainEvent::ContentDirty { .. } => {}
+                LocalDomainEvent::ClipboardActivity { pane } => {
+                    if let Some(local) = self.panes.get(&pane) {
+                        for request in local.vt.drain_clipboard_requests() {
+                            sink(DomainEvent::ClipboardRequest { pane, request });
+                        }
+                    }
+                }
                 LocalDomainEvent::Exited { pane } => {
                     if let Some(local) = self.panes.get_mut(&pane) {
                         local.exited = true;
@@ -219,6 +229,7 @@ fn image_digest(width: u32, height: u32, rgba: &[u8]) -> [u8; 32] {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LocalDomainEvent {
     ContentDirty { pane: PaneRef },
+    ClipboardActivity { pane: PaneRef },
     Exited { pane: PaneRef },
 }
 

--- a/crates/seance-mux/src/local.rs
+++ b/crates/seance-mux/src/local.rs
@@ -11,7 +11,7 @@ use seance_protocol::identity::{
 use seance_protocol::image_cache::{ImageCacheEvent, ImageFormat, ImagePayload};
 use seance_protocol::limits::MAX_RETAINED_PANE_UPDATES;
 use seance_protocol::mux::PaneUpdate;
-use seance_vt::{ClipboardRequest, VtEvent, VtSessionHandle, spawn_vt_session};
+use seance_vt::{VtEvent, VtSessionHandle, spawn_vt_session};
 
 use crate::{
     Domain, DomainEvent, MuxEvent, PaneError, PaneFrameHistory, PaneSpawnOptions, SpawnError,

--- a/crates/seance-vt/src/clipboard.rs
+++ b/crates/seance-vt/src/clipboard.rs
@@ -1,0 +1,224 @@
+//! OSC 52 clipboard request parsing.
+//!
+//! OSC 52 (xterm) lets the application drive the host's clipboard:
+//!
+//! - `ESC ] 52 ; <sel> ; <base64> BEL` — set the clipboard.
+//! - `ESC ] 52 ; <sel> ; ? BEL` — query the clipboard.
+//!
+//! `<sel>` is any combination of `c` (clipboard), `p`/`s` (primary/selection),
+//! `q` (secondary), and `0`–`7` (cut buffers). seance maps every recognized
+//! selector onto the OS clipboard — the host platforms we target (macOS,
+//! Wayland with arboard fallbacks) only expose a single clipboard, and tmux
+//! / vim drivers always send `c` anyway.
+
+use bytes::Bytes;
+
+/// A clipboard request decoded from an OSC 52 sequence. The VT layer parses
+/// the bytes; the application owns the OS clipboard (`arboard`) and is
+/// responsible for honoring or denying the request based on user config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClipboardRequest {
+    /// `OSC 52 ; <sel> ; <base64> ST` — set the clipboard contents.
+    /// `data` is the decoded UTF-8 byte stream (callers should re-validate
+    /// before treating it as text).
+    Write(Bytes),
+    /// `OSC 52 ; <sel> ; ? ST` — query the clipboard. The application is
+    /// expected to reply with another OSC 52 sequence carrying the encoded
+    /// contents (see [`encode_osc52_reply`]).
+    Read,
+}
+
+/// Parse the body of an OSC 52 command (i.e. the bytes between `OSC 52 ;` and
+/// the terminator). Returns `None` for malformed payloads — silently dropping
+/// is the xterm-compatible behavior.
+pub(crate) fn parse_osc52(content: &[u8]) -> Option<ClipboardRequest> {
+    let body = content.strip_prefix(b"52;")?;
+    let semi = body.iter().position(|&b| b == b';')?;
+    let (_selectors, rest) = body.split_at(semi);
+    let payload = &rest[1..];
+    if payload == b"?" {
+        return Some(ClipboardRequest::Read);
+    }
+    let decoded = base64_decode(payload)?;
+    Some(ClipboardRequest::Write(Bytes::from(decoded)))
+}
+
+/// Build an `ESC ] 52 ; c ; <base64> ESC \\` reply for the contents of the
+/// system clipboard. xterm uses the same selector the application asked
+/// for; we always answer with `c` since seance collapses every selector
+/// onto the single OS clipboard anyway.
+pub fn encode_osc52_reply(payload: &[u8]) -> Bytes {
+    let mut out = Vec::with_capacity(payload.len() * 4 / 3 + 8);
+    out.extend_from_slice(b"\x1b]52;c;");
+    base64_encode_into(payload, &mut out);
+    out.extend_from_slice(b"\x1b\\");
+    Bytes::from(out)
+}
+
+const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn base64_encode_into(input: &[u8], out: &mut Vec<u8>) {
+    let mut chunks = input.chunks_exact(3);
+    for chunk in &mut chunks {
+        let b0 = chunk[0];
+        let b1 = chunk[1];
+        let b2 = chunk[2];
+        out.push(ALPHABET[(b0 >> 2) as usize]);
+        out.push(ALPHABET[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize]);
+        out.push(ALPHABET[(((b1 & 0x0f) << 2) | (b2 >> 6)) as usize]);
+        out.push(ALPHABET[(b2 & 0x3f) as usize]);
+    }
+    let remainder = chunks.remainder();
+    match remainder.len() {
+        0 => {}
+        1 => {
+            let b0 = remainder[0];
+            out.push(ALPHABET[(b0 >> 2) as usize]);
+            out.push(ALPHABET[((b0 & 0x03) << 4) as usize]);
+            out.push(b'=');
+            out.push(b'=');
+        }
+        2 => {
+            let b0 = remainder[0];
+            let b1 = remainder[1];
+            out.push(ALPHABET[(b0 >> 2) as usize]);
+            out.push(ALPHABET[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize]);
+            out.push(ALPHABET[((b1 & 0x0f) << 2) as usize]);
+            out.push(b'=');
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn base64_decode(input: &[u8]) -> Option<Vec<u8>> {
+    let mut buf = Vec::with_capacity(input.len() * 3 / 4);
+    let mut group = 0u32;
+    let mut filled = 0u8;
+    let mut pad = 0u8;
+    for &byte in input {
+        // Whitespace is permitted between groups (some shells fold long
+        // OSC 52 payloads).
+        if matches!(byte, b'\r' | b'\n' | b'\t' | b' ') {
+            continue;
+        }
+        let value = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'a'..=b'z' => byte - b'a' + 26,
+            b'0'..=b'9' => byte - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            b'=' => {
+                pad = pad.saturating_add(1);
+                if pad > 2 {
+                    return None;
+                }
+                group <<= 6;
+                filled += 1;
+                if filled == 4 {
+                    // 1 pad encodes 2 data bytes, 2 pads encode 1 data byte.
+                    flush_group(group, 3 - pad, &mut buf);
+                    group = 0;
+                    filled = 0;
+                }
+                continue;
+            }
+            _ => return None,
+        };
+        if pad != 0 {
+            return None;
+        }
+        group = (group << 6) | u32::from(value);
+        filled += 1;
+        if filled == 4 {
+            flush_group(group, 3, &mut buf);
+            group = 0;
+            filled = 0;
+        }
+    }
+    if filled != 0 {
+        return None;
+    }
+    Some(buf)
+}
+
+fn flush_group(group: u32, take: u8, out: &mut Vec<u8>) {
+    let bytes = [(group >> 16) as u8, (group >> 8) as u8, group as u8];
+    for byte in bytes.iter().take(take as usize) {
+        out.push(*byte);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_write_with_clipboard_selector() {
+        let req = parse_osc52(b"52;c;aGVsbG8=").expect("parse");
+        assert_eq!(req, ClipboardRequest::Write(Bytes::from_static(b"hello")));
+    }
+
+    #[test]
+    fn parses_write_with_multiple_selectors() {
+        let req = parse_osc52(b"52;cps;aGVsbG8=").expect("parse");
+        assert_eq!(req, ClipboardRequest::Write(Bytes::from_static(b"hello")));
+    }
+
+    #[test]
+    fn parses_write_with_empty_selector() {
+        let req = parse_osc52(b"52;;aGVsbG8=").expect("parse");
+        assert_eq!(req, ClipboardRequest::Write(Bytes::from_static(b"hello")));
+    }
+
+    #[test]
+    fn parses_read_request() {
+        assert_eq!(parse_osc52(b"52;c;?"), Some(ClipboardRequest::Read));
+    }
+
+    #[test]
+    fn rejects_missing_payload_separator() {
+        assert_eq!(parse_osc52(b"52;c"), None);
+    }
+
+    #[test]
+    fn rejects_non_osc52_commands() {
+        assert_eq!(parse_osc52(b"7;file:///tmp"), None);
+    }
+
+    #[test]
+    fn rejects_invalid_base64() {
+        assert_eq!(parse_osc52(b"52;c;@@@@"), None);
+    }
+
+    #[test]
+    fn round_trips_known_payloads() {
+        for payload in [
+            &b""[..],
+            b"a",
+            b"ab",
+            b"abc",
+            b"abcd",
+            b"hello, world!",
+            b"\x00\x01\x02\x03\x04",
+        ] {
+            let encoded = encode_osc52_reply(payload);
+            let body = encoded
+                .strip_prefix(b"\x1b]52;c;")
+                .and_then(|rest| rest.strip_suffix(b"\x1b\\"))
+                .expect("reply framing");
+            let mut osc = Vec::from(b"52;c;");
+            osc.extend_from_slice(body);
+            let req = parse_osc52(&osc).expect("parse encoded reply");
+            assert_eq!(
+                req,
+                ClipboardRequest::Write(Bytes::copy_from_slice(payload))
+            );
+        }
+    }
+
+    #[test]
+    fn decodes_folded_base64_payload() {
+        let req = parse_osc52(b"52;c;aGVs\nbG8=").expect("parse");
+        assert_eq!(req, ClipboardRequest::Write(Bytes::from_static(b"hello")));
+    }
+}

--- a/crates/seance-vt/src/core.rs
+++ b/crates/seance-vt/src/core.rs
@@ -7,6 +7,7 @@ use libghostty_vt::style::RgbColor;
 use libghostty_vt::terminal::{Mode, ScrollViewport};
 use libghostty_vt::{RenderState, Terminal as VtTerminal, TerminalOptions};
 
+use crate::clipboard::{ClipboardRequest, parse_osc52};
 use crate::frame::{CursorInfo, CursorShape, DirtySnapshot};
 use crate::snapshot::{RowMeta, VtSnapshot};
 use crate::snapshot_extraction::{SnapshotExtraction, extract_snapshot};
@@ -14,6 +15,10 @@ use crate::terminal::install_png_decoder_for_this_thread;
 
 pub const DEFAULT_MAX_SCROLLBACK: usize = 10_000;
 pub(crate) const KITTY_IMAGE_STORAGE_LIMIT_BYTES: u64 = 320 * 1000 * 1000;
+/// Hard cap on bytes buffered while assembling a single OSC sequence. xterm
+/// and tmux flush long clipboard payloads in one go; 1 MiB covers a realistic
+/// "copy a whole file" use case while still bounding pathological inputs.
+const MAX_OSC_BUFFER: usize = 1 << 20;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VtCoreError {
@@ -63,6 +68,7 @@ pub(crate) struct VtCore {
     force_full_next_snapshot: bool,
     pwd: Option<String>,
     osc_state: OscState,
+    clipboard_requests: VecDeque<ClipboardRequest>,
 }
 
 impl VtCore {
@@ -109,6 +115,7 @@ impl VtCore {
             force_full_next_snapshot: false,
             pwd: None,
             osc_state: OscState::Ground,
+            clipboard_requests: VecDeque::new(),
         };
         core.seed_cursor_shape(options.initial_cursor_shape);
         Ok(core)
@@ -116,7 +123,7 @@ impl VtCore {
 
     pub(crate) fn feed(&mut self, bytes: &[u8]) {
         if !bytes.is_empty() {
-            self.track_osc7(bytes);
+            self.track_osc(bytes);
             self.vt.vt_write(bytes);
         }
     }
@@ -127,6 +134,10 @@ impl VtCore {
             out.push(bytes);
         }
         out
+    }
+
+    pub(crate) fn drain_clipboard_requests(&mut self) -> Vec<ClipboardRequest> {
+        self.clipboard_requests.drain(..).collect()
     }
 
     pub(crate) fn resize(
@@ -192,7 +203,7 @@ impl VtCore {
         self.dirty.ack_rendered(generation);
     }
 
-    fn track_osc7(&mut self, bytes: &[u8]) {
+    fn track_osc(&mut self, bytes: &[u8]) {
         for &byte in bytes {
             match (&mut self.osc_state, byte) {
                 (OscState::Ground, 0x1b) => self.osc_state = OscState::Esc,
@@ -202,7 +213,7 @@ impl VtCore {
                 (OscState::Esc, _) => self.osc_state = OscState::Ground,
                 (OscState::Osc(buf), 0x07 | 0x9c) => {
                     let content = std::mem::take(buf);
-                    self.apply_osc7(&content);
+                    self.dispatch_osc(&content);
                     self.osc_state = OscState::Ground;
                 }
                 (OscState::Osc(buf), 0x1b) => {
@@ -210,7 +221,7 @@ impl VtCore {
                     self.osc_state = OscState::OscEsc(content);
                 }
                 (OscState::Osc(buf), byte) => {
-                    if buf.len() < 4096 {
+                    if buf.len() < MAX_OSC_BUFFER {
                         buf.push(byte);
                     } else {
                         self.osc_state = OscState::Ground;
@@ -218,18 +229,18 @@ impl VtCore {
                 }
                 (OscState::OscEsc(buf), b'\\') => {
                     let content = std::mem::take(buf);
-                    self.apply_osc7(&content);
+                    self.dispatch_osc(&content);
                     self.osc_state = OscState::Ground;
                 }
                 (OscState::OscEsc(buf), 0x1b) => {
-                    if buf.len() < 4096 {
+                    if buf.len() < MAX_OSC_BUFFER {
                         buf.push(0x1b);
                     } else {
                         self.osc_state = OscState::Ground;
                     }
                 }
                 (OscState::OscEsc(buf), byte) => {
-                    if buf.len() < 4096 {
+                    if buf.len() < MAX_OSC_BUFFER {
                         buf.push(0x1b);
                         buf.push(byte);
                         self.osc_state = OscState::Osc(std::mem::take(buf));
@@ -241,10 +252,20 @@ impl VtCore {
         }
     }
 
-    fn apply_osc7(&mut self, content: &[u8]) {
-        let Some(raw) = content.strip_prefix(b"7;") else {
+    fn dispatch_osc(&mut self, content: &[u8]) {
+        // OSC 7 (current working directory) is consumed before the libghostty
+        // parser sees the sequence; OSC 52 is intercepted here so the renderer
+        // never tries to render escape bytes that should drive clipboard I/O.
+        if content.starts_with(b"7;") {
+            self.apply_osc7(&content[2..]);
             return;
-        };
+        }
+        if let Some(request) = parse_osc52(content) {
+            self.clipboard_requests.push_back(request);
+        }
+    }
+
+    fn apply_osc7(&mut self, raw: &[u8]) {
         if raw.is_empty() {
             self.pwd = None;
             return;
@@ -743,6 +764,33 @@ mod tests {
             cursor_dirty_delta(Some(prev), curr, 24),
             DirtySnapshot::Partial(vec![7]),
         );
+    }
+
+    #[test]
+    fn osc52_write_enqueued_when_fed() {
+        let mut core = core();
+        core.feed(b"\x1b]52;c;aGVsbG8=\x07");
+        let requests = core.drain_clipboard_requests();
+        assert_eq!(
+            requests,
+            vec![ClipboardRequest::Write(Bytes::from_static(b"hello"))],
+        );
+    }
+
+    #[test]
+    fn osc52_read_request_enqueued_when_fed() {
+        let mut core = core();
+        core.feed(b"\x1b]52;c;?\x1b\\");
+        let requests = core.drain_clipboard_requests();
+        assert_eq!(requests, vec![ClipboardRequest::Read]);
+    }
+
+    #[test]
+    fn osc7_still_routed_after_osc52_dispatch_rewrite() {
+        let mut core = core();
+        core.feed(b"\x1b]7;file:///tmp/work\x07");
+        let snapshot = core.snapshot().unwrap();
+        assert_eq!(snapshot.pwd.as_deref(), Some("/tmp/work"));
     }
 
     #[test]

--- a/crates/seance-vt/src/core.rs
+++ b/crates/seance-vt/src/core.rs
@@ -256,8 +256,8 @@ impl VtCore {
         // OSC 7 (current working directory) is consumed before the libghostty
         // parser sees the sequence; OSC 52 is intercepted here so the renderer
         // never tries to render escape bytes that should drive clipboard I/O.
-        if content.starts_with(b"7;") {
-            self.apply_osc7(&content[2..]);
+        if let Some(rest) = content.strip_prefix(b"7;") {
+            self.apply_osc7(rest);
             return;
         }
         if let Some(request) = parse_osc52(content) {

--- a/crates/seance-vt/src/lib.rs
+++ b/crates/seance-vt/src/lib.rs
@@ -5,6 +5,7 @@
 //! [`VtSnapshot`] values through [`SnapshotFrameSource`]. [`spawn_vt_session`]
 //! starts the Unix IO actor that owns VT + PTY.
 
+mod clipboard;
 mod core;
 mod frame;
 mod kitty_graphics;
@@ -18,6 +19,7 @@ mod terminal;
 #[doc(hidden)]
 pub mod test_support;
 
+pub use clipboard::{ClipboardRequest, encode_osc52_reply};
 pub use core::{DEFAULT_MAX_SCROLLBACK, VtCoreError};
 pub use frame::{
     CellAttrs, CellColor, CellView, CellVisitor, CursorInfo, CursorShape, DirtySnapshot,

--- a/crates/seance-vt/src/session.rs
+++ b/crates/seance-vt/src/session.rs
@@ -15,6 +15,7 @@ use bytes::{Buf, Bytes};
 
 pub use seance_protocol::frame::{Resize, ThemeColors};
 
+use crate::clipboard::ClipboardRequest;
 use crate::core::VtCoreError;
 use crate::frame::CursorShape;
 use crate::snapshot::VtSnapshot;
@@ -61,9 +62,17 @@ impl Default for VtSessionOptions {
 }
 
 /// Public events emitted by the VT actor.
+///
+/// All variants are pure wake-up signals — actual payloads (snapshots,
+/// clipboard requests) live in side-channels so the event itself can stay
+/// `Copy + Eq` for cheap deduplication.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VtEvent {
     ContentDirty,
+    /// One or more OSC 52 clipboard requests have been queued by the VT
+    /// thread. The consumer should drain them via
+    /// [`VtSessionHandle::drain_clipboard_requests`].
+    ClipboardActivity,
     Exited,
 }
 
@@ -173,12 +182,40 @@ impl std::error::Error for VtSessionError {
     }
 }
 
+/// Cross-thread queue for OSC 52 clipboard requests parsed by the actor. The
+/// actor pushes, the UI thread drains. The shared mutex is fine here because
+/// pushes happen at byte-feed rate (rare) and drains happen on the UI thread
+/// at event-loop rate.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ClipboardQueue {
+    inner: Arc<Mutex<VecDeque<ClipboardRequest>>>,
+}
+
+impl ClipboardQueue {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn push_many(&self, requests: impl IntoIterator<Item = ClipboardRequest>) -> bool {
+        let mut guard = self.inner.lock().expect("clipboard queue poisoned");
+        let before = guard.len();
+        guard.extend(requests);
+        guard.len() > before
+    }
+
+    fn drain(&self) -> Vec<ClipboardRequest> {
+        let mut guard = self.inner.lock().expect("clipboard queue poisoned");
+        guard.drain(..).collect()
+    }
+}
+
 /// Handle used by the UI thread to command a VT actor and read snapshots.
 pub struct VtSessionHandle {
     commands: mpsc::Sender<VtCommand>,
     poller: Arc<polling::Poller>,
     slot: SnapshotSlot,
     content_dirty_pending: Arc<AtomicBool>,
+    clipboard: ClipboardQueue,
     join: Option<JoinHandle<()>>,
 }
 
@@ -189,6 +226,14 @@ impl VtSessionHandle {
 
     pub fn clear_content_dirty_pending(&self) {
         self.content_dirty_pending.store(false, Ordering::SeqCst);
+    }
+
+    /// Drain and return any OSC 52 clipboard requests parsed by the actor.
+    /// Returns an empty vec when nothing is pending — callers wake on
+    /// [`VtEvent::ClipboardActivity`] but should treat that signal as a
+    /// hint and tolerate spurious drains.
+    pub fn drain_clipboard_requests(&self) -> Vec<ClipboardRequest> {
+        self.clipboard.drain()
     }
 
     pub fn write(&self, bytes: Bytes) -> Result<(), VtSessionError> {
@@ -460,6 +505,7 @@ impl SyncOutputGate {
 struct ContentNotifier<F> {
     slot: SnapshotSlot,
     content_dirty_pending: Arc<AtomicBool>,
+    clipboard: ClipboardQueue,
     event_sink: F,
 }
 
@@ -471,6 +517,15 @@ where
         self.slot.publish(snapshot);
         if !self.content_dirty_pending.swap(true, Ordering::SeqCst) {
             (self.event_sink)(VtEvent::ContentDirty);
+        }
+    }
+
+    fn forward_clipboard(&self, requests: Vec<ClipboardRequest>) {
+        if requests.is_empty() {
+            return;
+        }
+        if self.clipboard.push_many(requests) {
+            (self.event_sink)(VtEvent::ClipboardActivity);
         }
     }
 
@@ -501,11 +556,13 @@ mod unix_actor {
         let (command_tx, command_rx) = mpsc::channel();
         let slot = SnapshotSlot::new();
         let content_dirty_pending = Arc::new(AtomicBool::new(false));
+        let clipboard = ClipboardQueue::new();
         let (init_tx, init_rx) = mpsc::sync_channel(1);
 
         let thread_poller = Arc::clone(&poller);
         let thread_slot = slot.clone();
         let thread_pending = Arc::clone(&content_dirty_pending);
+        let thread_clipboard = clipboard.clone();
 
         let join = thread::Builder::new()
             .name("seance-vt-actor".into())
@@ -513,6 +570,7 @@ mod unix_actor {
                 let notifier = ContentNotifier {
                     slot: thread_slot,
                     content_dirty_pending: thread_pending,
+                    clipboard: thread_clipboard,
                     event_sink,
                 };
                 match VtActor::new(options, command_rx, thread_poller, notifier) {
@@ -532,6 +590,7 @@ mod unix_actor {
                 poller,
                 slot,
                 content_dirty_pending,
+                clipboard,
                 join: Some(join),
             }),
             Ok(Err(err)) => {
@@ -927,6 +986,8 @@ mod unix_actor {
             for bytes in self.core.drain_responses() {
                 self.pending_writes.push(bytes);
             }
+            self.notifier
+                .forward_clipboard(self.core.drain_clipboard_requests());
         }
 
         /// Publish a snapshot only if the parse produced visible content
@@ -995,6 +1056,7 @@ mod unix_actor {
             SnapshotSlot,
             Arc<AtomicBool>,
             Arc<Mutex<Vec<VtEvent>>>,
+            ClipboardQueue,
         );
 
         enum ScriptRead {
@@ -1081,11 +1143,13 @@ mod unix_actor {
             let (tx, rx) = mpsc::channel();
             let slot = SnapshotSlot::new();
             let pending = Arc::new(AtomicBool::new(false));
+            let clipboard = ClipboardQueue::new();
             let events = Arc::new(Mutex::new(Vec::new()));
             let sink_events = Arc::clone(&events);
             let notifier = ContentNotifier {
                 slot: slot.clone(),
                 content_dirty_pending: Arc::clone(&pending),
+                clipboard: clipboard.clone(),
                 event_sink: Box::new(move |event| sink_events.lock().unwrap().push(event))
                     as TestSink,
             };
@@ -1104,7 +1168,7 @@ mod unix_actor {
                 notifier,
             )
             .expect("scripted actor should construct");
-            (tx, actor, slot, pending, events)
+            (tx, actor, slot, pending, events, clipboard)
         }
 
         fn clear_wake_state(pending: &AtomicBool, events: &Mutex<Vec<VtEvent>>) {
@@ -1114,14 +1178,14 @@ mod unix_actor {
 
         #[test]
         fn scripted_actor_publishes_initial_snapshot() {
-            let (_tx, _actor, slot, _pending, events) = actor_with_script([]);
+            let (_tx, _actor, slot, _pending, events, _clip) = actor_with_script([]);
             assert!(slot.latest_snapshot().is_some());
             assert_eq!(events.lock().unwrap().as_slice(), &[VtEvent::ContentDirty]);
         }
 
         #[test]
         fn scripted_actor_preserves_write_order() {
-            let (tx, mut actor, _slot, _pending, _events) = actor_with_script([]);
+            let (tx, mut actor, _slot, _pending, _events, _clip) = actor_with_script([]);
             tx.send(VtCommand::Write(Bytes::from_static(b"a"))).unwrap();
             tx.send(VtCommand::Write(Bytes::from_static(b"bc")))
                 .unwrap();
@@ -1134,7 +1198,7 @@ mod unix_actor {
 
         #[test]
         fn scripted_actor_reads_pty_bytes_into_vt_core() {
-            let (_tx, mut actor, slot, pending, events) = actor_with_script([]);
+            let (_tx, mut actor, slot, pending, events, _clip) = actor_with_script([]);
             clear_wake_state(&pending, &events);
             actor.pty.push_read(b"hi");
 
@@ -1148,7 +1212,7 @@ mod unix_actor {
 
         #[test]
         fn scripted_actor_applies_visible_commands_without_reordering() {
-            let (tx, mut actor, slot, pending, events) = actor_with_script([]);
+            let (tx, mut actor, slot, pending, events, _clip) = actor_with_script([]);
             clear_wake_state(&pending, &events);
             tx.send(VtCommand::Resize {
                 cols: 10,
@@ -1179,7 +1243,7 @@ mod unix_actor {
 
         #[test]
         fn scripted_actor_ack_does_not_publish() {
-            let (tx, mut actor, slot, pending, events) = actor_with_script([]);
+            let (tx, mut actor, slot, pending, events, _clip) = actor_with_script([]);
             let generation = slot.latest_snapshot().unwrap().generation;
             clear_wake_state(&pending, &events);
             tx.send(VtCommand::AckRendered(generation)).unwrap();
@@ -1192,7 +1256,7 @@ mod unix_actor {
 
         #[test]
         fn dirty_rows_survive_actor_publication_until_render_ack() {
-            let (tx, mut actor, slot, pending, events) = actor_with_script([]);
+            let (tx, mut actor, slot, pending, events, _clip) = actor_with_script([]);
             let initial = slot.latest_snapshot().unwrap();
             tx.send(VtCommand::AckRendered(initial.generation)).unwrap();
             assert!(!actor.drain_and_apply_commands());
@@ -1217,7 +1281,8 @@ mod unix_actor {
 
         #[test]
         fn scripted_actor_reports_eof_deterministically() {
-            let (_tx, mut actor, _slot, _pending, _events) = actor_with_script([ScriptRead::Eof]);
+            let (_tx, mut actor, _slot, _pending, _events, _clip) =
+                actor_with_script([ScriptRead::Eof]);
             assert!(matches!(actor.read_pty_batch(), Ok(ReadOutcome::Eof)));
         }
 
@@ -1227,7 +1292,7 @@ mod unix_actor {
             // readability after the shell's first write but before its second
             // — the exact race that paints the cleared-with-home-cursor frame
             // on Ctrl-L in release builds.
-            let (_tx, mut actor, slot, pending, events) = actor_with_script([
+            let (_tx, mut actor, slot, pending, events, _clip) = actor_with_script([
                 ScriptRead::Data(Bytes::from_static(b"\x1b[H\x1b[2J")),
                 ScriptRead::WouldBlock,
                 ScriptRead::Data(Bytes::from_static(b"$ ")),
@@ -1243,7 +1308,7 @@ mod unix_actor {
 
         #[test]
         fn read_pty_batch_settles_at_most_once_per_batch() {
-            let (_tx, mut actor, slot, pending, events) = actor_with_script([
+            let (_tx, mut actor, slot, pending, events, _clip) = actor_with_script([
                 ScriptRead::Data(Bytes::from_static(b"a")),
                 ScriptRead::WouldBlock,
                 ScriptRead::Data(Bytes::from_static(b"b")),
@@ -1262,6 +1327,34 @@ mod unix_actor {
                 matches!(actor.pty.reads.front(), Some(ScriptRead::Data(_))),
                 "third chunk must remain queued for the next batch",
             );
+        }
+
+        #[test]
+        fn osc52_write_surfaces_clipboard_request_and_wakes() {
+            let (_tx, mut actor, _slot, pending, events, clipboard) = actor_with_script([]);
+            clear_wake_state(&pending, &events);
+            // OSC 52 ; c ; aGVsbG8= BEL  → set clipboard to "hello"
+            actor.pty.push_read(b"\x1b]52;c;aGVsbG8=\x07");
+
+            assert!(matches!(actor.read_pty_batch(), Ok(ReadOutcome::Alive)));
+
+            let requests = clipboard.drain();
+            assert_eq!(
+                requests,
+                vec![ClipboardRequest::Write(Bytes::from_static(b"hello"))],
+            );
+            assert!(events.lock().unwrap().contains(&VtEvent::ClipboardActivity),);
+        }
+
+        #[test]
+        fn osc52_read_request_surfaces_distinct_variant() {
+            let (_tx, mut actor, _slot, pending, events, clipboard) = actor_with_script([]);
+            clear_wake_state(&pending, &events);
+            actor.pty.push_read(b"\x1b]52;c;?\x07");
+
+            assert!(matches!(actor.read_pty_batch(), Ok(ReadOutcome::Alive)));
+
+            assert_eq!(clipboard.drain(), vec![ClipboardRequest::Read]);
         }
     }
 }
@@ -1316,6 +1409,7 @@ mod tests {
         let notifier = ContentNotifier {
             slot: slot.clone(),
             content_dirty_pending: Arc::clone(&pending),
+            clipboard: ClipboardQueue::new(),
             event_sink: move |event| sink_events.lock().unwrap().push(event),
         };
 
@@ -1478,6 +1572,7 @@ mod tests {
             poller,
             slot: SnapshotSlot::new(),
             content_dirty_pending: Arc::new(AtomicBool::new(false)),
+            clipboard: ClipboardQueue::new(),
             join: Some(join),
         };
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,8 +123,13 @@ seance-render-test -> seance-vt, seance-protocol, seance-frame
   rebuild still walks the full grid pending shape cache (#21).
 - **DEC 2026 synchronized output** [IMPLEMENTED] — VT Actor publication gate
   with a 150 ms watchdog.
-- **OSC 52 clipboard** [PLANNED: [M3][m3]] — read/write with paste-protection
-  prompt.
+- **OSC 52 clipboard** [IMPLEMENTED] — VT Core parses
+  `OSC 52 ; <sel> ; <base64|?> ST`, emits `ClipboardRequest::{Write, Read}`
+  through the VT actor, and the App layer
+  (`SurfaceState::handle_clipboard_request`) routes them through `arboard`,
+  echoing reads back via an OSC 52 reply. Gated by
+  `clipboard.{read,write} = "allow" | "ask" | "deny"`; `ask` denies-and-logs
+  until the M3 confirm-overlay UI lands.
 - **Kitty graphics protocol** [IMPLEMENTED] — transmission, decode (PNG and raw
   24/32-bit), per-image cache with 320 MB storage cap, placement resolution.
   Virtual placeholders (U+10EEEE), animation, and iTerm2 inline images remain

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,8 +128,9 @@ seance-render-test -> seance-vt, seance-protocol, seance-frame
   through the VT actor, and the App layer
   (`SurfaceState::handle_clipboard_request`) routes them through `arboard`,
   echoing reads back via an OSC 52 reply. Gated by
-  `clipboard.{read,write} = "allow" | "ask" | "deny"`; `ask` denies-and-logs
-  until the M3 confirm-overlay UI lands.
+  `clipboard.{read,write} = "allow" | "ask" | "deny"`, both default `deny`;
+  users opt in by setting `allow` (or `ask` once the M3 confirm-overlay UI
+  ships).
 - **Kitty graphics protocol** [IMPLEMENTED] — transmission, decode (PNG and raw
   24/32-bit), per-image cache with 320 MB storage cap, placement resolution.
   Virtual placeholders (U+10EEEE), animation, and iTerm2 inline images remain


### PR DESCRIPTION
Parse `ESC ] 52 ; <sel> ; <base64|?> ST` in the VT core OSC tracker and surface decoded requests through a new `ClipboardRequest` enum. The VT actor pushes parsed requests onto a `ClipboardQueue` shared with the UI thread and wakes consumers via `VtEvent::ClipboardActivity`. LocalDomain drains pending requests on wake and forwards them through `ClientRefresh::clipboard_requests`; the App layer routes each request through `arboard`, echoing reads back via an OSC 52 reply.

Authorization moves to `clipboard.{read,write} = "allow" | "ask" | "deny"` (was `bool`). The `ask` value denies-and logs for now; wiring up the confirm-overlay UI is tracked under the M3 modal work in #6.

Closes #32
Refs: #6