### PR TITLE
Fix cursor visibility when viewport is scrolled into scrollback

### DIFF
--- a/crates/seance-render-test/tests/layer1_logic.rs
+++ b/crates/seance-render-test/tests/layer1_logic.rs
@@ -51,6 +51,32 @@ fn hide_cursor_sequence_toggles_visibility() {
 }
 
 #[test]
+fn cursor_invisible_in_snapshot_when_viewport_is_scrolled_into_scrollback() {
+    // 3-row viewport, feed 9 lines so 6 land in the scrollback.
+    let mut term = HeadlessTerminal::new(8, 3).expect("construct");
+    for i in 0..9u8 {
+        term.feed(format!("row{i}\r\n").as_bytes());
+    }
+    let bottom = term.snapshot().expect("snapshot at bottom");
+    assert!(bottom.cursor.visible, "cursor visible at bottom of buffer");
+
+    // Negative delta scrolls up. Three lines is enough to push the cursor
+    // (anchored to the active screen) below the viewport.
+    term.scroll_lines(-3);
+    let scrolled = term.snapshot().expect("snapshot scrolled into scrollback");
+    assert!(
+        !scrolled.cursor.visible,
+        "cursor hidden while viewport is in scrollback",
+    );
+
+    // Scrolling back down past the bottom is a no-op past the active screen,
+    // so any value ≥ the prior up-scroll returns us to the bottom.
+    term.scroll_lines(9);
+    let back = term.snapshot().expect("snapshot after returning to bottom");
+    assert!(back.cursor.visible, "cursor visible after return to bottom");
+}
+
+#[test]
 fn cursor_position_sequence_moves_cursor() {
     let mut term = HeadlessTerminal::new(80, 24).expect("construct");
     // CSI Ps;Ps H — 1-based row;col; 5;10 → (col 9, row 4).

--- a/crates/seance-vt/src/snapshot_extraction.rs
+++ b/crates/seance-vt/src/snapshot_extraction.rs
@@ -83,24 +83,31 @@ pub(crate) fn extract_snapshot(
         let global_dirty = render_snapshot.dirty().ok();
         let mut dirty_rows = Vec::new();
 
-        let visible = render_snapshot.cursor_visible().unwrap_or(true);
-        let pos =
-            render_snapshot
-                .cursor_viewport()
-                .ok()
-                .flatten()
-                .map_or(GridPos::default(), |vp| GridPos {
+        // Cursor lives in the active screen, not the viewport. When the user
+        // scrolls into the scrollback `cursor_viewport()` returns `None` —
+        // suppress visibility so the bar/block/underline glyph doesn't get
+        // anchored to (0, 0). Matches ghostty's renderer/cursor.zig, which
+        // returns `null` from `style()` whenever `state.cursor.viewport` is
+        // null before considering mode/focus/blink.
+        let viewport_cursor = render_snapshot.cursor_viewport().ok().flatten();
+        let cursor_mode_visible = render_snapshot.cursor_visible().unwrap_or(true);
+        let (pos, wide) = viewport_cursor.map_or((GridPos::default(), false), |vp| {
+            (
+                GridPos {
                     col: vp.x,
                     row: vp.y,
-                });
+                },
+                vp.at_wide_tail,
+            )
+        });
         let shape = render_snapshot
             .cursor_visual_style()
             .ok()
             .and_then(map_cursor_shape);
         out.cursor = CursorInfo {
             pos,
-            visible,
-            wide: false,
+            visible: cursor_mode_visible && viewport_cursor.is_some(),
+            wide,
             shape,
         };
 

--- a/crates/seance-vt/src/test_support.rs
+++ b/crates/seance-vt/src/test_support.rs
@@ -71,6 +71,12 @@ impl HeadlessTerminal {
         self.core.is_cursor_visible()
     }
 
+    /// Scroll the viewport by `delta` rows. Negative values scroll up into the
+    /// scrollback, positive values scroll back down toward the active screen.
+    pub fn scroll_lines(&mut self, delta: i32) {
+        self.core.scroll_lines(delta);
+    }
+
     pub fn mode(&self, m: Mode) -> bool {
         self.core.mode(m)
     }


### PR DESCRIPTION
## Summary
This PR fixes cursor visibility handling in terminal snapshots when the viewport is scrolled into the scrollback buffer. Previously, the cursor would remain visible even when scrolled out of view, which didn't match the expected behavior where the cursor should only be visible when it's within the active screen viewport.

## Key Changes
- **Cursor visibility logic**: Modified `extract_snapshot()` to properly hide the cursor when `cursor_viewport()` returns `None`, which occurs when the user scrolls into the scrollback. The cursor is now only visible when both the cursor mode indicates visibility AND the viewport contains the cursor.
- **Wide character support**: Extracted the `at_wide_tail` property from the viewport cursor to properly track whether the cursor is on a wide character tail, fixing the hardcoded `wide: false` value.
- **Test coverage**: Added `cursor_invisible_in_snapshot_when_viewport_is_scrolled_into_scrollback()` test to verify cursor visibility is correctly suppressed when scrolled into scrollback and restored when scrolling back to the active screen.
- **API addition**: Exposed `scroll_lines()` method in `HeadlessTerminal` test support to enable scrollback testing.

## Implementation Details
The fix aligns with ghostty's renderer behavior (as noted in the comments), where the cursor style returns `null` whenever the viewport is `null`, before considering mode/focus/blink state. This ensures the cursor glyph (bar/block/underline) doesn't get anchored to an invalid position like (0, 0) when the viewport is in the scrollback.

https://claude.ai/code/session_01MXGyM2dVZS7NHiN5roKjVg