### PR TITLE
feat(app): add fullscreen toggle keybind (Enter)

### DIFF
--- a/crates/seance-app/src/command.rs
+++ b/crates/seance-app/src/command.rs
@@ -13,4 +13,5 @@ pub enum AppCommand {
     SelectAll,
     FontSizeDelta(i8),
     FontSizeReset,
+    ToggleFullscreen,
 }

--- a/crates/seance-app/src/events.rs
+++ b/crates/seance-app/src/events.rs
@@ -8,6 +8,7 @@ use winit::dpi::PhysicalPosition;
 use winit::event::{ElementState, MouseButton};
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::{Key, NamedKey};
+use winit::window::Fullscreen;
 
 use seance_input::{MouseAction, MouseEventInput, VtInput};
 
@@ -118,6 +119,16 @@ impl App {
             AppCommand::FontSizeReset => {
                 self.font_size = self.config.font.size;
                 self.apply_font_size();
+            }
+            AppCommand::ToggleFullscreen => {
+                if let Some(surface) = self.surface_mut() {
+                    let next = surface
+                        .window
+                        .fullscreen()
+                        .is_none()
+                        .then_some(Fullscreen::Borderless(None));
+                    surface.window.set_fullscreen(next);
+                }
             }
         }
     }

--- a/crates/seance-app/src/keybinds.rs
+++ b/crates/seance-app/src/keybinds.rs
@@ -5,7 +5,7 @@
 //! to `seance_input::InputHandler`.
 
 use winit::event::{ElementState, KeyEvent, Modifiers};
-use winit::keyboard::Key;
+use winit::keyboard::{Key, NamedKey};
 
 use crate::command::AppCommand;
 
@@ -24,19 +24,20 @@ impl Keybinds {
         if !modifiers.state().super_key() {
             return None;
         }
-        let Key::Character(c) = &event.logical_key else {
-            return None;
-        };
-        Some(match c.as_str() {
-            "q" => AppCommand::Quit,
-            "w" => AppCommand::CloseWindow,
-            "c" => AppCommand::Copy,
-            "v" => AppCommand::Paste,
-            "a" => AppCommand::SelectAll,
-            "+" | "=" => AppCommand::FontSizeDelta(1),
-            "-" => AppCommand::FontSizeDelta(-1),
-            "0" => AppCommand::FontSizeReset,
-            _ => return None,
-        })
+        match &event.logical_key {
+            Key::Character(c) => Some(match c.as_str() {
+                "q" => AppCommand::Quit,
+                "w" => AppCommand::CloseWindow,
+                "c" => AppCommand::Copy,
+                "v" => AppCommand::Paste,
+                "a" => AppCommand::SelectAll,
+                "+" | "=" => AppCommand::FontSizeDelta(1),
+                "-" => AppCommand::FontSizeDelta(-1),
+                "0" => AppCommand::FontSizeReset,
+                _ => return None,
+            }),
+            Key::Named(NamedKey::Enter) => Some(AppCommand::ToggleFullscreen),
+            _ => None,
+        }
     }
 }


### PR DESCRIPTION
Add support for toggling fullscreen mode via the Enter key when the super/command key is held. This complements the existing super+key shortcuts for quit, close window, copy, paste, select all, and font size adjustments.

Changes made:

- **`command.rs`**: Added `ToggleFullscreen` variant to `AppCommand` enum.
- **`keybinds.rs`**: Refactored key matching to handle both character and named keys. Added `NamedKey` import and pattern match for `Key::Named(NamedKey::Enter)` to dispatch the new command.
- **`events.rs`**: Implemented `ToggleFullscreen` handler that toggles between borderless fullscreen and windowed mode. Added `Fullscreen` import from `winit::window`.

The implementation checks the current fullscreen state and sets it to `Borderless(None)` if windowed, or `None` if already fullscreen.

https://claude.ai/code/session_01MQN4fun1K18V3XfGQsw9Ta