### PR TITLE
feat(macos): resolve dead keys via UCKeyTranslate

### DIFF
--- a/crates/seance-input/src/lib.rs
+++ b/crates/seance-input/src/lib.rs
@@ -324,9 +324,20 @@ impl InputHandler {
 
         #[cfg(target_os = "macos")]
         let composed = {
-            let alt_held = modifiers.state().alt_key();
+            let state = modifiers.state();
+            let alt_held = state.alt_key();
             let right = macos::uckey::right_option_held(modifiers);
             if composer_side(self.option_as_alt, alt_held, right) {
+                self.uckey.translate(code, modifiers)
+            } else if !alt_held
+                && !state.control_key()
+                && !state.super_key()
+                && event.text.as_deref().is_none_or(str::is_empty)
+            {
+                // Dead-key recovery: bare `^` and Shift+`^` (grave) on ISO
+                // layouts come through winit with empty text because
+                // NSTextInputClient buffers the composition. UCKeyTranslate
+                // with the no-dead-keys mask resolves the glyph synchronously.
                 self.uckey.translate(code, modifiers)
             } else {
                 None

--- a/crates/seance-input/src/lib.rs
+++ b/crates/seance-input/src/lib.rs
@@ -5,13 +5,13 @@
 //! clipboard, font size) are matched upstream before reaching here.
 
 mod keymap;
+#[cfg(target_os = "macos")]
+mod macos;
 
 use libghostty_vt::{key, mouse};
 use seance_protocol::frame::{MouseSize, MouseTracking, TerminalModes};
 use winit::event::{ElementState, KeyEvent, Modifiers, MouseButton};
-use winit::keyboard::{Key, PhysicalKey};
-#[cfg(target_os = "macos")]
-use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
+use winit::keyboard::PhysicalKey;
 
 /// Result of encoding a VT-bound key event.
 #[derive(Debug)]
@@ -50,6 +50,22 @@ impl OptionAsAlt {
             Self::Right => key::OptionAsAlt::Right,
             Self::Both => key::OptionAsAlt::True,
         }
+    }
+}
+
+/// Returns true when an Option-modified press should resolve through the
+/// macOS text composer (and therefore through `UCKeyTranslate` for dead
+/// keys) rather than emit an ESC-prefix. Composer side is the *opposite*
+/// of whatever side the configured policy treats as Alt.
+fn composer_side(policy: OptionAsAlt, alt_held: bool, right_option_held: bool) -> bool {
+    if !alt_held {
+        return false;
+    }
+    match policy {
+        OptionAsAlt::None => true,
+        OptionAsAlt::Left => right_option_held,
+        OptionAsAlt::Right => !right_option_held,
+        OptionAsAlt::Both => false,
     }
 }
 
@@ -117,6 +133,9 @@ fn map_mouse_button(button: MouseButton) -> mouse::Button {
 pub struct InputHandler {
     key_encoder: key::Encoder<'static>,
     mouse_encoder: mouse::Encoder<'static>,
+    option_as_alt: OptionAsAlt,
+    #[cfg(target_os = "macos")]
+    uckey: macos::uckey::UcKey,
 }
 
 impl Default for InputHandler {
@@ -129,6 +148,9 @@ impl Default for InputHandler {
         Self {
             key_encoder,
             mouse_encoder: mouse::Encoder::new().expect("mouse encoder"),
+            option_as_alt: OptionAsAlt::default(),
+            #[cfg(target_os = "macos")]
+            uckey: macos::uckey::UcKey::new(),
         }
     }
 }
@@ -142,6 +164,7 @@ impl InputHandler {
     /// with the `ALT_SIDE` bit on each event's mods) to decide whether to
     /// emit `ESC`-prefix for Option+key or pass the composed text through.
     pub fn set_option_as_alt(&mut self, mode: OptionAsAlt) {
+        self.option_as_alt = mode;
         self.key_encoder
             .set_macos_option_as_alt(mode.to_libghostty());
     }
@@ -299,11 +322,28 @@ impl InputHandler {
             return Vec::new();
         };
 
+        #[cfg(target_os = "macos")]
+        let composed = {
+            let alt_held = modifiers.state().alt_key();
+            let right = macos::uckey::right_option_held(modifiers);
+            if composer_side(self.option_as_alt, alt_held, right) {
+                self.uckey.translate(code, modifiers)
+            } else {
+                None
+            }
+        };
+        #[cfg(not(target_os = "macos"))]
+        let composed: Option<String> = None;
+
         key_event
             .set_key(gk)
             .set_action(keymap::map_action(event.state))
             .set_mods(keymap::map_mods(modifiers));
-        if let Some(text) = event.text.as_deref().filter(|t| is_safe_encoder_text(t)) {
+        let utf8 = composed
+            .as_deref()
+            .or(event.text.as_deref())
+            .filter(|t| is_safe_encoder_text(t));
+        if let Some(text) = utf8 {
             key_event.set_utf8(Some(text));
         }
 
@@ -311,18 +351,10 @@ impl InputHandler {
         let _ = self.key_encoder.encode_to_vec(&key_event, &mut buf);
 
         if tracing::enabled!(tracing::Level::TRACE) {
-            let logical = match &event.logical_key {
-                Key::Character(s) => Some(s.as_str()),
-                _ => None,
-            };
-            #[cfg(target_os = "macos")]
-            let all_mods = event.text_with_all_modifiers();
-            #[cfg(not(target_os = "macos"))]
-            let all_mods: Option<&str> = None;
             tracing::trace!(
-                "encode_key: code={code:?} text={:?} logical={logical:?} all_mods={all_mods:?} \
-                 mods={:?} -> {buf:02x?}",
+                "encode_key: code={code:?} text={:?} composed={:?} mods={:?} -> {buf:02x?}",
                 event.text.as_deref(),
+                composed.as_deref(),
                 key_event.mods(),
             );
         }
@@ -586,5 +618,42 @@ mod tests {
             h.encode_alt_scroll(0, alt_scroll_modes(true, true, false))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn composer_side_short_circuits_without_alt() {
+        for policy in [
+            OptionAsAlt::None,
+            OptionAsAlt::Left,
+            OptionAsAlt::Right,
+            OptionAsAlt::Both,
+        ] {
+            assert!(!composer_side(policy, false, false));
+            assert!(!composer_side(policy, false, true));
+        }
+    }
+
+    #[test]
+    fn composer_side_policy_none_always_composes_when_alt_held() {
+        assert!(composer_side(OptionAsAlt::None, true, false));
+        assert!(composer_side(OptionAsAlt::None, true, true));
+    }
+
+    #[test]
+    fn composer_side_policy_both_never_composes() {
+        assert!(!composer_side(OptionAsAlt::Both, true, false));
+        assert!(!composer_side(OptionAsAlt::Both, true, true));
+    }
+
+    #[test]
+    fn composer_side_policy_left_composes_only_when_right_held() {
+        assert!(!composer_side(OptionAsAlt::Left, true, false));
+        assert!(composer_side(OptionAsAlt::Left, true, true));
+    }
+
+    #[test]
+    fn composer_side_policy_right_composes_only_when_left_held() {
+        assert!(composer_side(OptionAsAlt::Right, true, false));
+        assert!(!composer_side(OptionAsAlt::Right, true, true));
     }
 }

--- a/crates/seance-input/src/macos.rs
+++ b/crates/seance-input/src/macos.rs
@@ -1,0 +1,1 @@
+pub mod uckey;

--- a/crates/seance-input/src/macos/uckey.rs
+++ b/crates/seance-input/src/macos/uckey.rs
@@ -136,9 +136,13 @@ impl UcKey {
 }
 
 fn carbon_mod_byte(mods: &Modifiers) -> u32 {
-    let mut byte = CARBON_OPTION;
-    if mods.state().shift_key() {
+    let state = mods.state();
+    let mut byte = 0;
+    if state.shift_key() {
         byte |= CARBON_SHIFT;
+    }
+    if state.alt_key() {
+        byte |= CARBON_OPTION;
     }
     byte
 }

--- a/crates/seance-input/src/macos/uckey.rs
+++ b/crates/seance-input/src/macos/uckey.rs
@@ -1,0 +1,211 @@
+//! Dead-key composition via `UCKeyTranslate`.
+//!
+//! winit's `KeyEvent::text` is sourced from `NSEvent.characters`, which on
+//! non-US layouts withholds dead-key glyphs (`Opt+n` reports `n` instead of
+//! `~`) until the composition resolves on the *follow-up* keypress. The
+//! terminal needs the glyph at press time, so we ask the Text Input Source
+//! for the active layout and call `UCKeyTranslate` with
+//! `kUCKeyTranslateNoDeadKeysMask` to force resolution per press.
+//!
+//! Only the FFI surface lives here. The composer-side gate (when the
+//! configured `OptionAsAlt` policy is consulted) lives in `lib.rs` so it
+//! stays unit-testable on non-macOS hosts.
+
+use std::cell::Cell;
+use std::ffi::c_void;
+use std::os::raw::c_ulong;
+use std::ptr;
+
+use winit::event::Modifiers;
+use winit::keyboard::{KeyCode, ModifiersKeyState};
+
+type CFTypeRef = *const c_void;
+type TISInputSourceRef = CFTypeRef;
+type CFDataRef = CFTypeRef;
+type CFStringRef = CFTypeRef;
+type UniCharCount = c_ulong;
+
+const KEY_ACTION_DOWN: u16 = 0;
+const NO_DEAD_KEYS_MASK: u32 = 1;
+
+// Carbon modifier byte (NSEventModifierFlags >> 8 & 0xff).
+const CARBON_SHIFT: u32 = 0x02;
+const CARBON_OPTION: u32 = 0x08;
+
+#[allow(non_snake_case, non_upper_case_globals)]
+#[link(name = "Carbon", kind = "framework")]
+unsafe extern "C" {
+    fn TISCopyCurrentKeyboardLayoutInputSource() -> TISInputSourceRef;
+    fn TISGetInputSourceProperty(source: TISInputSourceRef, property: CFStringRef) -> CFTypeRef;
+    fn LMGetKbdType() -> u8;
+    fn UCKeyTranslate(
+        key_layout_ptr: *const u8,
+        virtual_key_code: u16,
+        key_action: u16,
+        modifier_key_state: u32,
+        keyboard_type: u32,
+        key_translate_options: u32,
+        dead_key_state: *mut u32,
+        max_string_length: UniCharCount,
+        actual_string_length: *mut UniCharCount,
+        unicode_string: *mut u16,
+    ) -> i32;
+    static kTISPropertyUnicodeKeyLayoutData: CFStringRef;
+}
+
+#[allow(non_snake_case)]
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    fn CFDataGetBytePtr(data: CFDataRef) -> *const u8;
+}
+
+/// Holds a non-owning pointer into the active layout's `UCKeyboardLayout`
+/// bytes. The Text Input Source that owns those bytes is intentionally
+/// leaked for the process lifetime — TIS returns the same pointer while
+/// the layout is stable, and v1 doesn't subscribe to layout-change
+/// notifications. Users restart on layout swap.
+pub struct UcKey {
+    layout: Cell<*const u8>,
+}
+
+impl UcKey {
+    pub fn new() -> Self {
+        Self {
+            layout: Cell::new(ptr::null()),
+        }
+    }
+
+    /// Returns the composed character for `code` under `mods`, or `None`
+    /// when the key has no text mapping, the layout is unavailable, or
+    /// `UCKeyTranslate` produced an empty string.
+    pub fn translate(&self, code: KeyCode, mods: &Modifiers) -> Option<String> {
+        let virtual_key = map_keycode(code)?;
+        let layout = self.layout_ptr()?;
+        let mod_byte = carbon_mod_byte(mods);
+
+        let mut dead_state: u32 = 0;
+        let mut buf = [0u16; 4];
+        let mut actual: UniCharCount = 0;
+
+        let status = unsafe {
+            UCKeyTranslate(
+                layout,
+                virtual_key,
+                KEY_ACTION_DOWN,
+                mod_byte,
+                u32::from(LMGetKbdType()),
+                NO_DEAD_KEYS_MASK,
+                &mut dead_state,
+                buf.len() as UniCharCount,
+                &mut actual,
+                buf.as_mut_ptr(),
+            )
+        };
+        if status != 0 || actual == 0 {
+            return None;
+        }
+        let slice = &buf[..actual as usize];
+        let s: String = char::decode_utf16(slice.iter().copied())
+            .filter_map(Result::ok)
+            .collect();
+        if s.is_empty() { None } else { Some(s) }
+    }
+
+    fn layout_ptr(&self) -> Option<*const u8> {
+        let cached = self.layout.get();
+        if !cached.is_null() {
+            return Some(cached);
+        }
+        let ptr = unsafe {
+            let source = TISCopyCurrentKeyboardLayoutInputSource();
+            if source.is_null() {
+                return None;
+            }
+            let data = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData);
+            if data.is_null() {
+                return None;
+            }
+            CFDataGetBytePtr(data)
+        };
+        if ptr.is_null() {
+            return None;
+        }
+        self.layout.set(ptr);
+        Some(ptr)
+    }
+}
+
+fn carbon_mod_byte(mods: &Modifiers) -> u32 {
+    let mut byte = CARBON_OPTION;
+    if mods.state().shift_key() {
+        byte |= CARBON_SHIFT;
+    }
+    byte
+}
+
+/// True when right-Option is the side currently held. Mirrors
+/// `keymap::map_mods`, which sets `ALT_SIDE` only when `ralt_state` is
+/// `Pressed` because `lalt_state` may report `Unknown` on some platforms.
+pub fn right_option_held(mods: &Modifiers) -> bool {
+    matches!(mods.ralt_state(), ModifiersKeyState::Pressed)
+}
+
+fn map_keycode(code: KeyCode) -> Option<u16> {
+    Some(match code {
+        KeyCode::KeyA => 0x00,
+        KeyCode::KeyB => 0x0B,
+        KeyCode::KeyC => 0x08,
+        KeyCode::KeyD => 0x02,
+        KeyCode::KeyE => 0x0E,
+        KeyCode::KeyF => 0x03,
+        KeyCode::KeyG => 0x05,
+        KeyCode::KeyH => 0x04,
+        KeyCode::KeyI => 0x22,
+        KeyCode::KeyJ => 0x26,
+        KeyCode::KeyK => 0x28,
+        KeyCode::KeyL => 0x25,
+        KeyCode::KeyM => 0x2E,
+        KeyCode::KeyN => 0x2D,
+        KeyCode::KeyO => 0x1F,
+        KeyCode::KeyP => 0x23,
+        KeyCode::KeyQ => 0x0C,
+        KeyCode::KeyR => 0x0F,
+        KeyCode::KeyS => 0x01,
+        KeyCode::KeyT => 0x11,
+        KeyCode::KeyU => 0x20,
+        KeyCode::KeyV => 0x09,
+        KeyCode::KeyW => 0x0D,
+        KeyCode::KeyX => 0x07,
+        KeyCode::KeyY => 0x10,
+        KeyCode::KeyZ => 0x06,
+        KeyCode::Digit1 => 0x12,
+        KeyCode::Digit2 => 0x13,
+        KeyCode::Digit3 => 0x14,
+        KeyCode::Digit4 => 0x15,
+        KeyCode::Digit5 => 0x17,
+        KeyCode::Digit6 => 0x16,
+        KeyCode::Digit7 => 0x1A,
+        KeyCode::Digit8 => 0x1C,
+        KeyCode::Digit9 => 0x19,
+        KeyCode::Digit0 => 0x1D,
+        KeyCode::Minus => 0x1B,
+        KeyCode::Equal => 0x18,
+        KeyCode::BracketLeft => 0x21,
+        KeyCode::BracketRight => 0x1E,
+        KeyCode::Backslash => 0x2A,
+        KeyCode::Semicolon => 0x29,
+        KeyCode::Quote => 0x27,
+        KeyCode::Backquote => 0x32,
+        KeyCode::Comma => 0x2B,
+        KeyCode::Period => 0x2F,
+        KeyCode::Slash => 0x2C,
+        // `kVK_ISO_Section` — the §/± slot above Tab on ISO layouts; on
+        // Swiss German it carries the `<`/`>` glyphs and is the
+        // physical key for `Opt+^` (grave dead key).
+        KeyCode::IntlBackslash => 0x0A,
+        KeyCode::IntlYen => 0x5D,
+        KeyCode::IntlRo => 0x5E,
+        KeyCode::Space => 0x31,
+        _ => return None,
+    })
+}


### PR DESCRIPTION
Adds macOS-specific dead-key composition support to handle non-US keyboard layouts where `NSEvent.characters` withholds dead-key glyphs until the follow-up keypress. The terminal needs the glyph at press time, so we now call `UCKeyTranslate` with `kUCKeyTranslateNoDeadKeysMask` to force synchronous resolution.

**Key changes:**

- New `crates/seance-input/src/macos/uckey.rs` module wraps the Carbon FFI surface for `UCKeyTranslate`, providing a `UcKey` struct that caches the active keyboard layout and translates `KeyCode` + `Modifiers` to composed text.
- New `crates/seance-input/src/macos.rs` module re-exports the `uckey` submodule.
- Updated `InputHandler` to store `option_as_alt` policy and a `UcKey` instance (macOS only).
- Added `composer_side()` helper function that gates whether an Option-modified keypress should resolve through the text composer (opposite of the configured `OptionAsAlt` policy side).
- Modified `encode_key()` to consult `UCKeyTranslate` when:
  - Option is held and the configured policy routes that side to the composer, or
  - No modifiers are active and `event.text` is empty (dead-key recovery for bare `^` and Shift+`^` on ISO layouts).
- Simplified trace logging to remove platform-specific `text_with_all_modifiers()` call.
- Added comprehensive unit tests for `composer_side()` logic covering all policy variants.

The implementation intentionally leaks the Text Input Source for the process lifetime, as TIS returns the same pointer while the layout is stable and v1 does not subscribe to layout-change notifications.

https://claude.ai/code/session_0161UUVthMzjpR5j6syrMT8q