### PR TITLE
fix(ci): stop restoring Cargo bin cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Setup macOS sysroot
         run: tools/setup-sysroot.sh
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: "false"
+          key: no-cargo-bin
       - run: cargo build --workspace --all-targets
 
   clippy:
@@ -75,6 +78,9 @@ jobs:
       - name: Setup macOS sysroot
         run: tools/setup-sysroot.sh
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: "false"
+          key: no-cargo-bin
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
@@ -92,6 +98,9 @@ jobs:
       - name: Setup macOS sysroot
         run: tools/setup-sysroot.sh
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: "false"
+          key: no-cargo-bin
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest


### PR DESCRIPTION
## Summary

Disable rust-cache's Cargo bin caching for macOS build, clippy, and nextest jobs, and put those caches in a fresh `no-cargo-bin` namespace.

## Motivation

The macOS cargo jobs install Rust through mise before restoring rust-cache. Restoring `${CARGO_HOME}/bin` can bring back stale cargo/rustup proxy state from a different runner image, which matches the intermittent failures where `cargo <subcommand>` exits as `rustup-init`.

## Alternatives considered

Disabling rust-cache entirely would avoid the corrupted bin state, but would also throw away useful registry, git dependency, and target caches. The targeted `cache-bin: "false"` setting fixes the toolchain-manager coupling while preserving those caches.

## Notes

Validated the workflow YAML parses and confirmed the three rust-cache steps include `cache-bin: "false"` and `key: no-cargo-bin`.

No tracked issue.
