### PR TITLE
fix(render): correct baseline calculation for centered cell metrics

### DIFF
--- a/crates/seance-render/src/text/cosmic.rs
+++ b/crates/seance-render/src/text/cosmic.rs
@@ -366,7 +366,7 @@ fn cell_metrics_from_face(
         .unwrap_or(base_cell_height)
         .max(1) as f32;
     let baseline_from_bottom =
-        (face.face_baseline_from_bottom - (cell_height - face.face_height) / 2.0).round();
+        (face.face_baseline_from_bottom + (cell_height - face.face_height) / 2.0).round();
     let baseline = (cell_height - baseline_from_bottom).clamp(0.0, cell_height);
 
     CellMetrics {
@@ -459,7 +459,11 @@ mod tests {
 
         assert_eq!(metrics.cell_width, 9.0);
         assert_eq!(metrics.cell_height, 22.0);
-        assert_eq!(metrics.baseline, 10.0);
+        // Face baseline sits at 18.2 - 14.0 = 4.2 from the top of the face.
+        // Centering shifts it down by half the extra cell height
+        // ((22 - 18.2)/2 = 1.9), so the cell baseline is at 4.2 + 1.9 = 6.1
+        // — rounded through baseline_from_bottom = 16 to land at 22 - 16 = 6.
+        assert_eq!(metrics.baseline, 6.0);
     }
 
     #[test]


### PR DESCRIPTION
The baseline calculation in `cell_metrics_from_face` was subtracting the centering offset when it should have been adding it. When a glyph face is smaller than the cell height, the face is centered vertically within the cell. The baseline position must shift downward by half the extra space, not upward.

Changed the operator from `-` to `+` in the baseline_from_bottom calculation, and updated the corresponding test assertion to reflect the correct expected baseline position. The test now includes a detailed comment explaining the calculation: the face baseline sits 4.2 units from the top, centering shifts it down by 1.9 units, yielding a cell baseline of 6.0 after rounding through the intermediate baseline_from_bottom value.

This fixes vertical text alignment for fonts where the face height is smaller than the computed cell height.