### PR TITLE
fix: tmux mouse selection, multi-click detection, and copy-mode Enter

### DIFF
--- a/crates/seance-app/src/events.rs
+++ b/crates/seance-app/src/events.rs
@@ -156,11 +156,15 @@ impl App {
         // the user is holding Shift to force local selection. The encoder
         // itself filters X10/Normal and the no-button-held case under 1002.
         if modes.mouse_tracking.reports_motion() && !shift_held {
+            // libghostty's encoder drops button-event (DECSET 1002)
+            // motion when `button` is `None`, so we must forward the
+            // button currently held to keep drag bytes flowing. tmux
+            // relies on this drag stream to resize panes.
             let input = MouseEventInput {
                 action: MouseAction::Motion,
-                button: None,
+                button: surface.mouse.drag_button,
                 position_px: clamp_position(position),
-                any_button_pressed: surface.mouse.is_down,
+                any_button_pressed: surface.mouse.drag_button.is_some(),
                 mods: surface.modifiers,
                 size: surface.renderer.mouse_size(),
             };
@@ -194,12 +198,22 @@ impl App {
                 ElementState::Pressed => MouseAction::Press,
                 ElementState::Released => MouseAction::Release,
             };
-            // Update `is_down` BEFORE encoding so that any-button-pressed
+            // Update drag state BEFORE encoding so that any-button-pressed
             // reflects the post-event state when reporting under DECSET
             // 1002 motion (xterm reports drag bytes carrying the held
             // button, and the very first motion after press needs the
             // bit set).
-            surface.mouse.is_down = state == ElementState::Pressed;
+            match state {
+                ElementState::Pressed => {
+                    surface.mouse.drag_button = Some(button);
+                }
+                ElementState::Released => {
+                    if surface.mouse.drag_button == Some(button) {
+                        surface.mouse.drag_button = None;
+                    }
+                }
+            }
+            surface.mouse.is_down = surface.mouse.drag_button.is_some();
             let input = MouseEventInput {
                 action,
                 button: Some(button),

--- a/crates/seance-app/src/events.rs
+++ b/crates/seance-app/src/events.rs
@@ -7,7 +7,6 @@ use bytes::Bytes;
 use winit::dpi::PhysicalPosition;
 use winit::event::{ElementState, MouseButton};
 use winit::event_loop::ActiveEventLoop;
-use winit::keyboard::{Key, NamedKey};
 use winit::window::Fullscreen;
 
 use seance_input::{MouseAction, MouseEventInput, VtInput};
@@ -51,19 +50,6 @@ impl App {
                 surface.mark_dirty();
             }
             self.execute_app_command(event_loop, cmd);
-            return;
-        }
-
-        // Bare Enter on an active local selection: copy + flash + dismiss
-        // instead of forwarding to the PTY. Modified Enter (Ctrl/Shift/etc.)
-        // still forwards normally so existing shortcuts keep working.
-        if event.state == ElementState::Pressed
-            && matches!(event.logical_key, Key::Named(NamedKey::Enter))
-            && modifiers.state().is_empty()
-            && let Some(surface) = self.surface_mut()
-            && surface.has_selection()
-        {
-            surface.flash_copy_selection(SELECTION_FLASH);
             return;
         }
 

--- a/crates/seance-app/src/mouse.rs
+++ b/crates/seance-app/src/mouse.rs
@@ -1,12 +1,21 @@
 use std::time::{Duration, Instant};
 
 use winit::dpi::PhysicalPosition;
+use winit::event::MouseButton;
 
 const MULTI_CLICK_WINDOW: Duration = Duration::from_millis(500);
 
 pub(crate) struct MouseState {
     pub(crate) cursor_pos: PhysicalPosition<f64>,
     pub(crate) is_down: bool,
+    /// Most recent button held during PTY-forwarded mouse tracking.
+    /// `None` between releases or while the local-selection path owns
+    /// the drag. Set on press, cleared on the matching release. We
+    /// thread this through motion events because libghostty's encoder
+    /// drops button-event (DECSET 1002) motion when `button` is `None`
+    /// — tmux uses 1002 by default, so without it pane-border drags
+    /// never reach the server.
+    pub(crate) drag_button: Option<MouseButton>,
     click_count: u8,
     last_click_time: Instant,
     last_click_pos: (u16, u16),
@@ -17,6 +26,7 @@ impl Default for MouseState {
         Self {
             cursor_pos: PhysicalPosition::new(0.0, 0.0),
             is_down: false,
+            drag_button: None,
             click_count: 0,
             last_click_time: Instant::now(),
             last_click_pos: (0, 0),

--- a/crates/seance-input/src/lib.rs
+++ b/crates/seance-input/src/lib.rs
@@ -133,6 +133,12 @@ fn map_mouse_button(button: MouseButton) -> mouse::Button {
 pub struct InputHandler {
     key_encoder: key::Encoder<'static>,
     mouse_encoder: mouse::Encoder<'static>,
+    /// Last size pushed to `mouse_encoder` via `set_size`. Tracked here
+    /// because the libghostty wrapper resets the encoder's last-cell
+    /// motion dedup state on every `set_size` call — even when the
+    /// value is unchanged — so we must skip the call when nothing has
+    /// actually changed.
+    mouse_size: Option<MouseSize>,
     option_as_alt: OptionAsAlt,
     #[cfg(target_os = "macos")]
     uckey: macos::uckey::UcKey,
@@ -145,9 +151,17 @@ impl Default for InputHandler {
         // xterm/Ghostty defaults). Without this, the encoder drops the ALT
         // bit and just emits the un-prefixed character.
         key_encoder.set_alt_esc_prefix(true);
+        let mut mouse_encoder = mouse::Encoder::new().expect("mouse encoder");
+        // Dedup motion to one report per cell change. Without this, every
+        // sub-pixel cursor jitter during a held button forwards a motion
+        // byte; tmux then reads `Press → Motion → Release` for what was a
+        // simple click and counts it as a drag, breaking the multi-click
+        // detector that drives `TripleClick1Pane` / copy-mode entry.
+        mouse_encoder.set_track_last_cell(true);
         Self {
             key_encoder,
-            mouse_encoder: mouse::Encoder::new().expect("mouse encoder"),
+            mouse_encoder,
+            mouse_size: None,
             option_as_alt: OptionAsAlt::default(),
             #[cfg(target_os = "macos")]
             uckey: macos::uckey::UcKey::new(),
@@ -275,16 +289,19 @@ impl InputHandler {
         } else {
             mouse::Format::X10
         });
-        self.mouse_encoder.set_size(mouse::EncoderSize {
-            screen_width: input.size.screen_width,
-            screen_height: input.size.screen_height,
-            cell_width: input.size.cell_width.max(1),
-            cell_height: input.size.cell_height.max(1),
-            padding_top: input.size.padding_top,
-            padding_bottom: input.size.padding_bottom,
-            padding_left: input.size.padding_left,
-            padding_right: input.size.padding_right,
-        });
+        if self.mouse_size != Some(input.size) {
+            self.mouse_encoder.set_size(mouse::EncoderSize {
+                screen_width: input.size.screen_width,
+                screen_height: input.size.screen_height,
+                cell_width: input.size.cell_width.max(1),
+                cell_height: input.size.cell_height.max(1),
+                padding_top: input.size.padding_top,
+                padding_bottom: input.size.padding_bottom,
+                padding_left: input.size.padding_left,
+                padding_right: input.size.padding_right,
+            });
+            self.mouse_size = Some(input.size);
+        }
         self.mouse_encoder
             .set_any_button_pressed(input.any_button_pressed);
 
@@ -507,6 +524,21 @@ mod tests {
             modes(MouseTracking::Button, true),
         );
         assert!(out.is_some());
+    }
+
+    #[test]
+    fn motion_at_same_cell_dedupes() {
+        let mut h = InputHandler::new();
+        let m = modes(MouseTracking::Button, true);
+        // Seed the encoder's last_cell with a Press at (0,0).
+        h.encode_mouse_event(input(MouseAction::Press, Some(MouseButton::Left), true), m)
+            .expect("press should encode and seed last_cell");
+        // A subsequent Motion at the same cell must not emit bytes —
+        // tmux's multi-click detector breaks if Press → Motion → Release
+        // arrives for every click of a triple-click.
+        let dup =
+            h.encode_mouse_event(input(MouseAction::Motion, Some(MouseButton::Left), true), m);
+        assert!(dup.is_none(), "motion at the same cell should dedup");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three coupled fixes that together let tmux's mouse-driven copy mode work end-to-end against seance:

- **`fix(app): drop bare-Enter copy intercept so tmux receives Enter`** — `on_keyboard_input` was swallowing bare Enter whenever any local selection existed, copying it via `flash_copy_selection` and returning without forwarding `\r`. tmux's `copy-mode-vi` binds `y` and Enter to cancel-on-yank actions; with the intercept in place, Enter never reached tmux after a stray local selection (e.g. from an earlier triple-click in alt-screen) and copy mode appeared stuck.
- **`fix(input): forward held button on motion under DECSET 1002`** — libghostty's mouse encoder drops button-event motion when its `button` field is `None`, but `on_cursor_moved` was always passing `None`. Every drag byte was silently swallowed during tmux's default 1002 stream, so tmux saw `press → (nothing) → release` and treated each drag as a click. Track the held button in `MouseState::drag_button` and forward it on motion; derive `is_down` from `drag_button.is_some()`.
- **`fix(input): dedup motion to one report per cell change` (folded into the same commit)** — uncovered by the first input fix: libghostty's `set_track_last_cell` motion dedup was off and `encode_mouse_event` re-applied `set_size` on every event, which unconditionally resets the encoder's `last_cell` in the libghostty C wrapper. Every sub-pixel cursor jitter during a held button forwarded a motion byte; tmux on macOS read `press → motion → release` for a steady click, classified it as `MouseDrag1Pane`, and the multi-click counter never reached `TripleClick1Pane` — triple-click yank stayed in copy mode. Enable motion dedup at construction time and skip redundant `set_size` calls by caching the size on `InputHandler::mouse_size`.

## Motivation

User reports: "selection in tmux doesn't work — no visible selection at all" and "tmux stays in copy mode after triple-clicking to yank a line." Their tmux config (`xkef/dotfiles tmux/.config/tmux/conf.d/02-copy-mode.conf`) has `set -g mouse on`, `set-clipboard on`, `mode-keys vi`, an explicit `unbind -T copy-mode-vi MouseDragEnd1Pane` so drag selections persist until the user yanks with `y`, and tmux 3.x's default `TripleClick1Pane` (enter copy mode + `select-line`). That workflow requires (a) tmux to see mouse drag motion at all (held-button forwarding), (b) tmux to count rapid clicks as multi-clicks rather than micro-drags (cell-change dedup), and (c) seance not to swallow the user's terminating Enter (bare-Enter removal).

## Notes

The three changes are independent and review separately:

- **Bare-Enter removal** is a single-block deletion in `crates/seance-app/src/events.rs` plus the now-unused `winit::keyboard::{Key, NamedKey}` import. The existing keystroke path already clears stale local selections on a non-`Ignore` Pressed event, so Enter both clears the stale selection and forwards `\r` in one pass. Cmd+C, double/triple-click flash-copy, and the `SELECTION_FLASH` constant are unchanged.
- **Held-button-on-motion** threads `drag_button: Option<MouseButton>` through press/motion/release in `crates/seance-app/src/events.rs` + `crates/seance-app/src/mouse.rs` so libghostty's encoder receives a non-`None` button on every reported motion event.
- **Motion dedup** turns on `mouse_encoder.set_track_last_cell(true)` once at construction and caches the last-applied `MouseSize` on `InputHandler` so `set_size` is only re-applied when it actually changes — otherwise libghostty's C wrapper wipes the `last_cell` dedup state on every call. New test `motion_at_same_cell_dedupes` exercises the dedup path under `MouseTracking::Button` + SGR.

Validated locally: `cargo fmt --all`, `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all clean (273 tests pass; the new test is `seance_input::tests::motion_at_same_cell_dedupes`).

Refs: #33
