### PR TITLE
refactor(render): resolve selection on the CPU into bg_cells

### DIFF
--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -96,17 +96,16 @@ impl App {
                 .mux
                 .pane_view(surface.active_pane)
                 .and_then(|view| view.cursor_shape());
+            let selection = surface.selection_range();
             if let Some(mut source) = surface
                 .mux
                 .pane_view(surface.active_pane)
                 .and_then(|view| view.frame_source())
             {
-                surface.renderer.update_frame(&mut source);
+                surface.renderer.update_frame(&mut source, selection);
             }
         }
-        let selection = surface.selection_range();
         let hovered_link = surface.hovered_link_range();
-        surface.render_inputs.selection = selection;
         surface.render_inputs.hovered_link = hovered_link;
         // Prefer the VT-reported shape; fall back to the user's configured
         // default when the VT has no opinion. Refreshed every frame so that

--- a/crates/seance-render/src/gpu/shaders/cell.wgsl
+++ b/crates/seance-render/src/gpu/shaders/cell.wgsl
@@ -19,17 +19,8 @@ struct Uniforms {
     overlay_shape: u32,
     overlay_pos: vec2<u32>,
     overlay_color: vec4<f32>,
-    selection_start: vec2<u32>,
-    selection_end: vec2<u32>,
-    selection_color: vec4<f32>,
-    // alpha == 0 means "no override"; glyphs in selection then fall
-    // back to the cell's effective bg for natural contrast against
-    // selection_color.
-    selection_fg: vec4<f32>,
-    selection_active: u32,
     baseline: f32,
     hovered_link_active: u32,
-    _pad_link: u32,
     hovered_link_start: vec2<u32>,
     hovered_link_end: vec2<u32>,
     hovered_link_color: vec4<f32>,
@@ -40,6 +31,7 @@ struct Uniforms {
 const ATLAS_MASK: u32 = 0xFFu;
 const CURSOR_GLYPH_FLAGS_MASK: u32 = 0xFF00u;
 const MIN_CONTRAST_FLAG: u32 = 0x10000u;
+const IN_SELECTION_FLAG: u32 = 0x20000u;
 
 // ================================================================
 // Min-contrast (WCAG relative luminance in linearized sRGB)
@@ -87,32 +79,6 @@ fn apply_min_contrast(fg: vec3<f32>, bg: vec3<f32>, min_ratio: f32) -> vec3<f32>
         return vec3<f32>(1.0, 1.0, 1.0);
     }
     return vec3<f32>(0.0, 0.0, 0.0);
-}
-
-// ================================================================
-// Selection helper
-// ================================================================
-
-fn is_in_selection(col: u32, row: u32) -> bool {
-    if uniforms.selection_active == 0u {
-        return false;
-    }
-    let s = uniforms.selection_start;
-    let e = uniforms.selection_end;
-
-    if row < s.y || row > e.y {
-        return false;
-    }
-    if s.y == e.y {
-        return col >= s.x && col <= e.x;
-    }
-    if row == s.y {
-        return col >= s.x;
-    }
-    if row == e.y {
-        return col <= e.x;
-    }
-    return true;
 }
 
 fn is_in_hovered_link(col: u32, row: u32) -> bool {
@@ -195,13 +161,6 @@ fn fs_cell_bg(in: FullScreenOut) -> @location(0) vec4<f32> {
     let idx = row * uniforms.grid_size.x + col;
     let packed = bg_cells[idx];
     var color = unpack_rgba(packed);
-
-    if is_in_selection(col, row) {
-        let sel = uniforms.selection_color;
-        // Tmux-style: paint the cell bg fully opaque so glyphs sit on a
-        // solid block instead of an alpha tint.
-        color = vec4<f32>(sel.rgb, 1.0);
-    }
 
     if uniforms.cursor_visible != 0u
        && uniforms.overlay_shape != 0u
@@ -301,18 +260,13 @@ fn vs_cell_text(
     let bg_srgb = unpack_rgba(bg_packed);
     let effective_bg = select(bg_srgb.rgb, uniforms.bg_color.rgb, bg_srgb.a < 0.01);
 
+    // Selection colors are resolved on the CPU into instance.color and
+    // bg_cells; the flag only keeps selection winning over cursor
+    // inversion.
+    let in_selection = (instance.atlas_and_flags & IN_SELECTION_FLAG) != 0u;
+
     var color = instance.color;
-    if is_in_selection(instance.grid_pos.x, instance.grid_pos.y) {
-        // Selection wins over cursor inversion. Use the explicit
-        // selection_fg if the theme provides one (alpha != 0); else
-        // fall back to the cell's effective bg for contrast against the
-        // (now opaque) selection bg.
-        if uniforms.selection_fg.a > 0.0 {
-            color = vec4<f32>(uniforms.selection_fg.rgb, color.a);
-        } else {
-            color = vec4<f32>(effective_bg, color.a);
-        }
-    } else if (at_cursor || at_cursor_wide) && !is_cursor_glyph {
+    if (at_cursor || at_cursor_wide) && !is_cursor_glyph && !in_selection {
         if uniforms.overlay_shape == 1u {
             // Block cursor fills the cell; invert glyph to bg for legibility.
             color = vec4<f32>(effective_bg, color.a);

--- a/crates/seance-render/src/gpu/uniforms.rs
+++ b/crates/seance-render/src/gpu/uniforms.rs
@@ -34,7 +34,7 @@ impl From<ProtocolCursorShape> for CursorShape {
 }
 
 /// Layout must match the `Uniforms` struct in `cell.wgsl` exactly.
-const _: () = assert!(size_of::<Uniforms>() == 272);
+const _: () = assert!(size_of::<Uniforms>() == 224);
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
@@ -52,21 +52,13 @@ pub(crate) struct Uniforms {
     pub overlay_shape: u32,
     pub overlay_pos: [u32; 2],
     pub overlay_color: [f32; 4],
-    pub selection_start: [u32; 2],
-    pub selection_end: [u32; 2],
-    pub selection_color: [f32; 4],
-    /// RGBA selection foreground. `a == 0` is the sentinel for "no
-    /// override" — glyphs inside the selection then fall back to their
-    /// effective bg, which gives natural contrast against `selection_color`.
-    pub selection_fg: [f32; 4],
-    pub selection_active: u32,
     pub baseline: f32,
     pub hovered_link_active: u32,
-    /// Padding to satisfy WGSL `vec2<u32>` 8-byte alignment for the
-    /// hovered_link range below.
-    pub _pad_link: u32,
     pub hovered_link_start: [u32; 2],
     pub hovered_link_end: [u32; 2],
+    /// Padding to satisfy WGSL `vec4<f32>` 16-byte alignment for
+    /// `hovered_link_color` below.
+    pub _pad_link_color: [u32; 2],
     pub hovered_link_color: [f32; 4],
 }
 
@@ -78,15 +70,6 @@ impl Uniforms {
         inputs: &RenderInputs,
         theme: &Theme,
     ) -> Self {
-        let (sel_start, sel_end, sel_active) = match &inputs.selection {
-            Some((start, end)) => (
-                [start.col as u32, start.row as u32],
-                [end.col as u32, end.row as u32],
-                1u32,
-            ),
-            None => ([0u32; 2], [0u32; 2], 0u32),
-        };
-
         let (link_start, link_end, link_active) = match &inputs.hovered_link {
             Some(range) if range.start.row <= range.end.row => (
                 [u32::from(range.start.col), u32::from(range.start.row)],
@@ -114,25 +97,11 @@ impl Uniforms {
             overlay_shape: inputs.cursor_shape as u32,
             overlay_pos: [fi.cursor_pos[0] as u32, fi.cursor_pos[1] as u32],
             overlay_color: u8x4_to_f32(theme.cursor),
-            selection_start: sel_start,
-            selection_end: sel_end,
-            selection_color: theme.selection_bg,
-            selection_fg: match theme.selection_fg {
-                Some([r, g, b]) => [
-                    f32::from(r) / 255.0,
-                    f32::from(g) / 255.0,
-                    f32::from(b) / 255.0,
-                    1.0,
-                ],
-                // alpha=0 sentinel → wgsl falls back to cell bg.
-                None => [0.0, 0.0, 0.0, 0.0],
-            },
-            selection_active: sel_active,
             baseline: fi.baseline,
             hovered_link_active: link_active,
-            _pad_link: 0,
             hovered_link_start: link_start,
             hovered_link_end: link_end,
+            _pad_link_color: [0; 2],
             hovered_link_color: [
                 f32::from(theme.fg[0]) / 255.0,
                 f32::from(theme.fg[1]) / 255.0,

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -44,7 +44,6 @@ pub struct HoveredLinkRange {
 pub struct RenderInputs {
     pub vt_cursor_visible: bool,
     pub cursor_shape: CursorShape,
-    pub selection: Option<(GridPos, GridPos)>,
     pub hovered_link: Option<HoveredLinkRange>,
 }
 
@@ -53,7 +52,6 @@ impl Default for RenderInputs {
         Self {
             vt_cursor_visible: true,
             cursor_shape: CursorShape::Bar,
-            selection: None,
             hovered_link: None,
         }
     }
@@ -157,7 +155,14 @@ impl TerminalRenderer {
             .resize(winit::dpi::PhysicalSize::new(width, height));
     }
 
-    pub fn update_frame(&mut self, source: &mut dyn FrameSource) {
+    /// Rebuild the CPU-side frame. `selection` is the active selection in
+    /// row-major reading order; it is resolved into the cell colors here,
+    /// so any selection change requires a rebuild to become visible.
+    pub fn update_frame(
+        &mut self,
+        source: &mut dyn FrameSource,
+        selection: Option<(GridPos, GridPos)>,
+    ) {
         let bg_color = self.effective_bg_color();
         let min_contrast = self.min_contrast;
         self.cell_builder.build_frame(
@@ -170,6 +175,7 @@ impl TerminalRenderer {
                 theme: &self.theme,
                 bg_color,
                 min_contrast,
+                selection,
             },
         );
         if let Some(fi) = self.cell_builder.last_frame() {

--- a/crates/seance-render/src/text/cell_builder.rs
+++ b/crates/seance-render/src/text/cell_builder.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use rustc_hash::FxBuildHasher;
 use seance_config::Theme;
 use seance_frame::{CellView, CellVisitor, FrameSource};
-use seance_protocol::frame::{CellColor, DirtySnapshot};
+use seance_protocol::frame::{CellColor, DirtySnapshot, GridPos};
 
 use super::atlas::{AtlasEntry, GlyphAtlas};
 use super::backend::{CellMetrics, FontAttrs, GlyphFormat, GlyphId, ShapedGlyph, TextBackend};
@@ -41,6 +41,7 @@ pub struct CellText {
 const _: () = assert!(size_of::<CellText>() == 32);
 
 const TEXT_FLAG_MIN_CONTRAST: u32 = 1 << 16;
+const TEXT_FLAG_IN_SELECTION: u32 = 1 << 17;
 
 pub struct FrameInfo {
     pub cell_width: f32,
@@ -64,6 +65,10 @@ pub struct BuildFrameConfig<'a> {
     pub theme: &'a Theme,
     pub bg_color: [u8; 4],
     pub min_contrast: f32,
+    /// Inclusive selection range in row-major reading order. Selection is
+    /// resolved on the CPU into `bg_cells` and the per-glyph colors,
+    /// matching Ghostty; the cell shader has no selection logic.
+    pub selection: Option<(GridPos, GridPos)>,
 }
 
 type GlyphSlots = HashMap<GlyphId, AtlasEntry, FxBuildHasher>;
@@ -90,6 +95,7 @@ struct CellSlot {
     col: u16,
     fg: [u8; 4],
     min_contrast: bool,
+    selected: bool,
 }
 
 /// A single grid cell that bypassed shaping because its grapheme is a
@@ -103,6 +109,7 @@ struct ProceduralCell {
     codepoint: char,
     fg: [u8; 4],
     min_contrast: bool,
+    selected: bool,
 }
 
 /// A contiguous group of cells on the same row sharing one [`FontAttrs`],
@@ -132,12 +139,13 @@ impl ShapeRun {
         }
     }
 
-    fn push_cell(&mut self, col: u16, fg: [u8; 4], min_contrast: bool, text: &str) {
+    fn push_cell(&mut self, col: u16, fg: [u8; 4], min_contrast: bool, selected: bool, text: &str) {
         self.slots.push(CellSlot {
             byte_offset: self.text.len() as u32,
             col,
             fg,
             min_contrast,
+            selected,
         });
         self.text.push_str(text);
     }
@@ -183,6 +191,10 @@ pub struct CellBuilder {
     shape_scratch: Vec<ShapedGlyph>,
     last_frame: Option<FrameInfo>,
     last_dirty: DirtySnapshot,
+    /// Selection rendered into the previous frame's `bg_cells`. Selection
+    /// lives outside the VT, so its rows never appear in the VT dirty set;
+    /// comparing against this widens `last_dirty` when the range moves.
+    last_selection: Option<(GridPos, GridPos)>,
 }
 
 impl CellBuilder {
@@ -201,6 +213,7 @@ impl CellBuilder {
             // First frame must be a full upload — there's nothing on the GPU
             // yet for a `Partial` write to layer onto.
             last_dirty: DirtySnapshot::Full,
+            last_selection: None,
         }
     }
 
@@ -230,10 +243,21 @@ impl CellBuilder {
         };
         let cursor = source.cursor();
 
+        if config.selection != self.last_selection {
+            widen_dirty_rows(
+                &mut self.last_dirty,
+                self.last_selection,
+                config.selection,
+                geom.grid_rows,
+            );
+            self.last_selection = config.selection;
+        }
+
         walk_grid_into_runs(
             source,
             &geom,
             config.theme,
+            config.selection,
             &mut self.bg_cells,
             &mut self.runs,
             &mut self.procedural_cells,
@@ -365,6 +389,7 @@ fn walk_grid_into_runs(
     source: &mut dyn FrameSource,
     geom: &FrameGeometry,
     theme: &Theme,
+    selection: Option<(GridPos, GridPos)>,
     bg_cells: &mut Vec<[u8; 4]>,
     runs: &mut Vec<ShapeRun>,
     procedural_cells: &mut Vec<ProceduralCell>,
@@ -383,11 +408,65 @@ fn walk_grid_into_runs(
         procedural_cells,
         open: None,
         theme,
+        selection,
+        selection_bg: [
+            (theme.selection_bg[0] * 255.0).round() as u8,
+            (theme.selection_bg[1] * 255.0).round() as u8,
+            (theme.selection_bg[2] * 255.0).round() as u8,
+        ],
         cols: geom.grid_cols,
         rows: geom.grid_rows,
     };
     source.visit_cells(&mut visitor);
     visitor.flush();
+}
+
+/// Whether `(row, col)` falls inside the inclusive row-major `selection`
+/// range.
+fn in_selection(selection: Option<(GridPos, GridPos)>, row: u16, col: u16) -> bool {
+    let Some((s, e)) = selection else {
+        return false;
+    };
+    if row < s.row || row > e.row {
+        return false;
+    }
+    if s.row == e.row {
+        return col >= s.col && col <= e.col;
+    }
+    if row == s.row {
+        return col >= s.col;
+    }
+    if row == e.row {
+        return col <= e.col;
+    }
+    true
+}
+
+/// Fold the rows spanned by `old` and `new` selections into `dirty` so the
+/// GPU re-uploads them even when the VT reports those rows unchanged.
+fn widen_dirty_rows(
+    dirty: &mut DirtySnapshot,
+    old: Option<(GridPos, GridPos)>,
+    new: Option<(GridPos, GridPos)>,
+    grid_rows: u16,
+) {
+    if matches!(dirty, DirtySnapshot::Full) || grid_rows == 0 {
+        return;
+    }
+    let mut rows = match std::mem::replace(dirty, DirtySnapshot::Clean) {
+        DirtySnapshot::Partial(rows) => rows,
+        _ => Vec::new(),
+    };
+    for (s, e) in [old, new].into_iter().flatten() {
+        for row in s.row..=e.row.min(grid_rows - 1) {
+            rows.push(row);
+        }
+    }
+    rows.sort_unstable();
+    rows.dedup();
+    if !rows.is_empty() {
+        *dirty = DirtySnapshot::Partial(rows);
+    }
 }
 
 /// Text-aware pass: shape each run through the cache, ensure every glyph
@@ -419,6 +498,9 @@ fn shape_runs(
             let mut atlas_and_flags = u32::from(entry.is_color);
             if slot.min_contrast {
                 atlas_and_flags |= TEXT_FLAG_MIN_CONTRAST;
+            }
+            if slot.selected {
+                atlas_and_flags |= TEXT_FLAG_IN_SELECTION;
             }
             out.push(CellText {
                 glyph_pos: entry.pos,
@@ -482,6 +564,9 @@ struct RunBuilder<'a> {
     procedural_cells: &'a mut Vec<ProceduralCell>,
     open: Option<ShapeRun>,
     theme: &'a Theme,
+    selection: Option<(GridPos, GridPos)>,
+    /// `theme.selection_bg` quantized once to the `bg_cells` byte format.
+    selection_bg: [u8; 3],
     cols: u16,
     rows: u16,
 }
@@ -510,7 +595,14 @@ impl CellVisitor for RunBuilder<'_> {
         if view.attrs.inverse {
             std::mem::swap(&mut fg_rgb, &mut bg_rgb);
         }
-        if bg_rgb != theme_bg {
+        let selected = in_selection(self.selection, row, col);
+        if selected {
+            // Tmux-style: selection paints a fully opaque bg, taking
+            // precedence over the cell's SGR background, so glyphs sit on
+            // a solid block instead of an alpha tint.
+            let sel = self.selection_bg;
+            self.bg_cells[idx] = [sel[0], sel[1], sel[2], 255];
+        } else if bg_rgb != theme_bg {
             self.bg_cells[idx] = [bg_rgb[0], bg_rgb[1], bg_rgb[2], 255];
         }
 
@@ -520,6 +612,12 @@ impl CellVisitor for RunBuilder<'_> {
             return;
         }
 
+        if selected {
+            // Explicit theme selection-fg wins; otherwise fall back to the
+            // cell's effective bg for contrast against the opaque
+            // selection bg.
+            fg_rgb = self.theme.selection_fg.unwrap_or(bg_rgb);
+        }
         let alpha = if view.attrs.faint { FAINT_ALPHA } else { 255 };
         let fg = [fg_rgb[0], fg_rgb[1], fg_rgb[2], alpha];
 
@@ -535,6 +633,7 @@ impl CellVisitor for RunBuilder<'_> {
                 codepoint: c,
                 fg,
                 min_contrast,
+                selected,
             });
             return;
         }
@@ -554,10 +653,13 @@ impl CellVisitor for RunBuilder<'_> {
         }
         // Either the existing run extends, or the branch above just opened
         // a fresh one — `open` is `Some` either way.
-        self.open
-            .as_mut()
-            .expect("open run set above")
-            .push_cell(col, fg, min_contrast, view.text);
+        self.open.as_mut().expect("open run set above").push_cell(
+            col,
+            fg,
+            min_contrast,
+            selected,
+            view.text,
+        );
     }
 }
 
@@ -611,6 +713,9 @@ fn emit_procedural_cells(
         let mut atlas_and_flags = u32::from(entry.is_color);
         if cell.min_contrast {
             atlas_and_flags |= TEXT_FLAG_MIN_CONTRAST;
+        }
+        if cell.selected {
+            atlas_and_flags |= TEXT_FLAG_IN_SELECTION;
         }
         out.push(CellText {
             glyph_pos: entry.pos,
@@ -743,6 +848,17 @@ mod tests {
             theme,
             bg_color: [0, 0, 0, 255],
             min_contrast: 1.0,
+            selection: None,
+        }
+    }
+
+    fn build_config_with_selection(
+        theme: &Theme,
+        selection: Option<(GridPos, GridPos)>,
+    ) -> BuildFrameConfig<'_> {
+        BuildFrameConfig {
+            selection,
+            ..build_config(theme)
         }
     }
 
@@ -756,6 +872,37 @@ mod tests {
         theme: &Theme,
     ) -> (Vec<[u8; 4]>, Vec<ShapeRun>) {
         let (bg, runs, _) = collect_runs_with_procedural(cols, rows, cells, theme);
+        (bg, runs)
+    }
+
+    /// Variant of [`collect_runs`] with an active selection range.
+    fn collect_runs_selected(
+        cols: u16,
+        rows: u16,
+        cells: &[FakeCell<'_>],
+        theme: &Theme,
+        selection: (GridPos, GridPos),
+    ) -> (Vec<[u8; 4]>, Vec<ShapeRun>) {
+        let mut source = FakeFrame::new(cols, rows, cells);
+        let geom = FrameGeometry {
+            cell_width: 10.0,
+            cell_height: 20.0,
+            grid_cols: cols,
+            grid_rows: rows,
+            grid_padding: [0.0; 4],
+        };
+        let mut bg = Vec::new();
+        let mut runs = Vec::new();
+        let mut procedural = Vec::new();
+        walk_grid_into_runs(
+            &mut source,
+            &geom,
+            theme,
+            Some(selection),
+            &mut bg,
+            &mut runs,
+            &mut procedural,
+        );
         (bg, runs)
     }
 
@@ -782,6 +929,7 @@ mod tests {
             &mut source,
             &geom,
             theme,
+            None,
             &mut bg,
             &mut runs,
             &mut procedural,
@@ -1053,9 +1201,9 @@ mod tests {
         // Three cells "a", "é" (2 bytes), "b" → text "aéb",
         // slots at byte_offset [0, 1, 3].
         let mut run = ShapeRun::new(0, FontAttrs::default());
-        run.push_cell(0, [1, 1, 1, 255], true, "a");
-        run.push_cell(1, [2, 2, 2, 255], true, "é");
-        run.push_cell(2, [3, 3, 3, 255], true, "b");
+        run.push_cell(0, [1, 1, 1, 255], true, false, "a");
+        run.push_cell(1, [2, 2, 2, 255], true, false, "é");
+        run.push_cell(2, [3, 3, 3, 255], true, false, "b");
 
         assert_eq!(run.slot_for_cluster(0).col, 0);
         assert_eq!(run.slot_for_cluster(1).col, 1);
@@ -1537,5 +1685,157 @@ mod tests {
         // and land at the start of the grayscale plane again.
         assert_eq!(second.glyph_pos, first.glyph_pos);
         assert_eq!(second.glyph_size, first.glyph_size);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // CPU-resolved selection (issue #262)
+    // ────────────────────────────────────────────────────────────────────
+
+    fn pos(col: u16, row: u16) -> GridPos {
+        GridPos { col, row }
+    }
+
+    #[test]
+    fn selection_bg_is_opaque_and_overrides_sgr_background() {
+        let theme = Theme::blank();
+        let cells = [
+            ("a", CellColor::Default, CellColor::Palette(1), plain()),
+            ("b", CellColor::Default, CellColor::Palette(1), plain()),
+            ("c", CellColor::Default, CellColor::Palette(1), plain()),
+        ];
+        let (bg, _runs) = collect_runs_selected(3, 1, &cells, &theme, (pos(1, 0), pos(1, 0)));
+
+        assert_eq!(bg[0], [205, 0, 0, 255]);
+        assert_eq!(bg[1], [200, 200, 200, 255], "selection replaces SGR bg");
+        assert_eq!(bg[2], [205, 0, 0, 255]);
+    }
+
+    #[test]
+    fn selection_paints_empty_cells() {
+        let theme = Theme::blank();
+        let cells = [("", CellColor::Default, CellColor::Default, plain())];
+        let (bg, runs) = collect_runs_selected(1, 1, &cells, &theme, (pos(0, 0), pos(0, 0)));
+
+        assert_eq!(bg[0], [200, 200, 200, 255]);
+        assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn selection_fg_uses_explicit_theme_override() {
+        // Theme::blank provides selection_fg = Some(theme bg).
+        let theme = Theme::blank();
+        let cells = [("x", CellColor::Palette(2), CellColor::Default, plain())];
+        let (_bg, runs) = collect_runs_selected(1, 1, &cells, &theme, (pos(0, 0), pos(0, 0)));
+
+        assert_eq!(runs[0].slots[0].fg, [0, 0, 0, 255]);
+        assert!(runs[0].slots[0].selected);
+    }
+
+    #[test]
+    fn selection_fg_falls_back_to_cell_effective_bg() {
+        let mut theme = Theme::blank();
+        theme.selection_fg = None;
+        let cells = [
+            ("d", CellColor::Default, CellColor::Default, plain()),
+            ("p", CellColor::Default, CellColor::Palette(4), plain()),
+        ];
+        let (_bg, runs) = collect_runs_selected(2, 1, &cells, &theme, (pos(0, 0), pos(1, 0)));
+
+        // Default-bg cell falls back to the theme bg; SGR-bg cell to its
+        // own resolved bg.
+        assert_eq!(runs[0].slots[0].fg, [0, 0, 0, 255]);
+        assert_eq!(runs[0].slots[1].fg, [0, 0, 238, 255]);
+    }
+
+    #[test]
+    fn selection_range_spans_rows_in_reading_order() {
+        let theme = Theme::blank();
+        let cells: Vec<FakeCell<'_>> = (0..9)
+            .map(|_| ("x", CellColor::Default, CellColor::Default, plain()))
+            .collect();
+        // (1,0) → (1,2): row 0 from col 1, all of row 1, row 2 up to col 1.
+        let (bg, _runs) = collect_runs_selected(3, 3, &cells, &theme, (pos(1, 0), pos(1, 2)));
+
+        let sel = [200, 200, 200, 255];
+        let off = [0, 0, 0, 0];
+        assert_eq!(bg, vec![off, sel, sel, sel, sel, sel, sel, sel, off]);
+    }
+
+    #[test]
+    fn selected_glyphs_carry_selection_flag() {
+        let theme = Theme::blank();
+        let cells = [
+            ("a", CellColor::Default, CellColor::Default, plain()),
+            ("─", CellColor::Default, CellColor::Default, plain()),
+            ("b", CellColor::Default, CellColor::Default, plain()),
+        ];
+        let mut source = FakeFrame::new(3, 1, &cells);
+        let mut backend = distributing_backend();
+        let mut builder = CellBuilder::new();
+
+        builder.build_frame(
+            &mut source,
+            &mut backend,
+            build_config_with_selection(&theme, Some((pos(1, 0), pos(2, 0)))),
+        );
+
+        // Shape-run glyphs emit first ("a", "b"), then the procedural "─".
+        let flags: Vec<(u16, bool)> = builder
+            .text_cells()
+            .iter()
+            .map(|c| {
+                (
+                    c.grid_pos[0],
+                    c.atlas_and_flags & TEXT_FLAG_IN_SELECTION != 0,
+                )
+            })
+            .collect();
+        assert_eq!(flags, vec![(0, false), (2, true), (1, true)]);
+    }
+
+    #[test]
+    fn selection_change_widens_dirty_rows() {
+        let theme = Theme::blank();
+        let cells = [
+            ("a", CellColor::Default, CellColor::Default, plain()),
+            ("b", CellColor::Default, CellColor::Default, plain()),
+            ("c", CellColor::Default, CellColor::Default, plain()),
+            ("d", CellColor::Default, CellColor::Default, plain()),
+        ];
+        let mut source = FakeFrame::new(1, 4, &cells);
+        let mut backend = StubBackend::new();
+        let mut builder = CellBuilder::new();
+        let selection = Some((pos(0, 1), pos(0, 2)));
+
+        builder.build_frame(&mut source, &mut backend, build_config(&theme));
+
+        // The VT reports Clean from here on; only the selection changes.
+        builder.build_frame(
+            &mut source,
+            &mut backend,
+            build_config_with_selection(&theme, selection),
+        );
+        assert_eq!(*builder.last_dirty(), DirtySnapshot::Partial(vec![1, 2]));
+
+        builder.build_frame(
+            &mut source,
+            &mut backend,
+            build_config_with_selection(&theme, selection),
+        );
+        assert_eq!(*builder.last_dirty(), DirtySnapshot::Clean);
+
+        builder.build_frame(&mut source, &mut backend, build_config(&theme));
+        assert_eq!(*builder.last_dirty(), DirtySnapshot::Partial(vec![1, 2]));
+    }
+
+    #[test]
+    fn widen_dirty_rows_merges_and_clamps() {
+        let mut dirty = DirtySnapshot::Partial(vec![0]);
+        widen_dirty_rows(&mut dirty, None, Some((pos(0, 2), pos(0, 9))), 4);
+        assert_eq!(dirty, DirtySnapshot::Partial(vec![0, 2, 3]));
+
+        let mut dirty = DirtySnapshot::Full;
+        widen_dirty_rows(&mut dirty, None, Some((pos(0, 0), pos(0, 1))), 4);
+        assert_eq!(dirty, DirtySnapshot::Full);
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,12 +212,12 @@ A layer holds `DrawOp` tags, not GPU state; the frame's render pass walks the
 schedule and binds the matching pipeline per op. The four op kinds share 3 bind
 groups (uniforms / bg_cells SSBO / atlas textures + sampler):
 
-| Op             | Vertex              | Fragment                                          | Blend               |
-| -------------- | ------------------- | ------------------------------------------------- | ------------------- |
-| `BgColorFill`  | fullscreen triangle | solid uniforms.bg_color                           | none                |
-| `CellBg`       | fullscreen triangle | per-cell bg from SSBO + selection + cursor shapes | premultiplied alpha |
-| `CellText`     | instanced quads     | atlas sample, min-contrast, cursor color swap     | premultiplied alpha |
-| `Images(band)` | instanced quads     | per-image texture sample                          | premultiplied alpha |
+| Op             | Vertex              | Fragment                                      | Blend               |
+| -------------- | ------------------- | --------------------------------------------- | ------------------- |
+| `BgColorFill`  | fullscreen triangle | solid uniforms.bg_color                       | none                |
+| `CellBg`       | fullscreen triangle | per-cell bg from SSBO + cursor shapes         | premultiplied alpha |
+| `CellText`     | instanced quads     | atlas sample, min-contrast, cursor color swap | premultiplied alpha |
+| `Images(band)` | instanced quads     | per-image texture sample                      | premultiplied alpha |
 
 The terminal cell content is the reference plane, not a single z, so the three
 Kitty `PlacementLayer` bands live as sub-roles of the `Z_MAIN` layer rather than
@@ -232,9 +232,10 @@ SubRole::Above     Kitty above-text
 ```
 
 Stacked window backgrounds sit at negative z; floating UI at positive z — each a
-`layer_for_z(z)` call, no type edits. Cursor-over-text and the selection overlay
-are currently baked into the `cell_bg`/`cell_text` shaders; promoting them to
-distinct `Above` ops is future work.
+`layer_for_z(z)` call, no type edits. Selection is resolved on the CPU into the
+`bg_cells` SSBO and per-glyph colors (Ghostty-style); cursor-over-text stays
+baked into the `cell_bg`/`cell_text` shaders, and promoting it to a distinct
+`Above` op is future work.
 
 ### Offscreen post-pass infrastructure [PLANNED: [M4][m4] + [M7][m7]]
 


### PR DESCRIPTION
Part of the M4 shader cleanup (#7): selection moves out of `cell.wgsl` so later UI layers (status/tab bar, modals, splits, IME) build on a cell shader that is not tangled with overlay logic. Ghostty resolves selection on the CPU while building the per-cell background buffer and its shader carries no selection code; this reverts seance to that approach.

Changes, by module:

- `seance-render/src/text/cell_builder.rs` — the per-cell walk (`RunBuilder::cell`, the successor of the `write_cell_bg` path referenced in the issue) now paints selected cells' `bg_cells` entries with the opaque theme selection-bg, taking precedence over the cell's SGR background, and rewrites the glyph color to the theme selection-fg with fallback to the cell's effective bg when the theme provides none — both matching the previous shader semantics exactly. `BuildFrameConfig` gains the `selection` range.
- Dirty tracking: selection lives outside the VT, so its rows never appear in the VT dirty set. `CellBuilder` remembers the previously rendered range and folds the rows spanned by the old and new selections into `last_dirty`, so the partial bg upload covers selection changes on otherwise clean frames (the GPU upload path short-circuits on `Clean`).
- `gpu/shaders/cell.wgsl` — `is_in_selection` and the selection branches in `fs_cell_bg` / `vs_cell_text` are deleted. A per-instance `IN_SELECTION` flag (bit 17 of `atlas_and_flags`) keeps selection winning over cursor inversion, preserving the previous branch order for glyphs under the cursor.
- `gpu/uniforms.rs` — the five `selection_*` fields are gone; the uniform block shrinks from 272 to 224 bytes.
- `renderer.rs` / `seance-app` — `RenderInputs.selection` becomes an `update_frame` parameter, since selection is consumed at frame-build time rather than render time. Every selection mutation in the app already marks the surface content-dirty, so rebuilds happen exactly when needed.

No intended visual change. New unit tests cover selection bg precedence over SGR bg, explicit/fallback selection-fg, multi-row range shape, the selection flag on shaped and procedural glyphs, and dirty-row widening across selection changes.

Closes #262

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dzmu361dAzpvRTLhvPDj1k)_