### PR TITLE
feat: wire versioning, CHANGELOG, and seance --version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
 
 concurrency:
@@ -10,6 +11,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version:
+    name: tag/version consistency
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag must match workspace version
+        run: |
+          version="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ "${GITHUB_REF_NAME}" != "v${version}" ]; then
+            echo "tag ${GITHUB_REF_NAME} does not match workspace version ${version}" >&2
+            exit 1
+          fi
+
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `seance --version` / `-V` prints `séance <version> (<git sha>)` and exits
+  without initializing the window or GPU.
+
+## [0.1.0]
+
+Pre-release development baseline; no release has been cut yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Development setup, everyday commands, and commit/PR/branch conventions live in
+[CLAUDE.md](CLAUDE.md). `tools/ci.sh` runs every CI gate locally; a green run
+there is the bar for pushing.
+
+## Versioning
+
+seance follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+`MAJOR.MINOR.PATCH`. While the project is pre-1.0 (`0.x`), minor versions may
+break configuration, protocol, or API compatibility; patch versions are fixes
+only.
+
+The version is defined exactly once, in `[workspace.package]` in the root
+`Cargo.toml`; every crate inherits it via `version.workspace = true`. Release
+tags are `v<version>` (e.g. `v0.1.0`), and CI rejects any tag that does not
+match the workspace version.
+
+User-visible changes are recorded in [CHANGELOG.md](CHANGELOG.md) under
+`[Unreleased]`, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+format, as part of the PR that makes them.
+
+## Releasing
+
+1. Run `tools/bump-version.sh <new-version>`. It updates the workspace version,
+   refreshes `Cargo.lock`, moves the `[Unreleased]` entries in `CHANGELOG.md`
+   into a new dated `[<new-version>]` section, and prints the tag command. It
+   never pushes.
+2. Review the diff and commit it as `chore(release): v<new-version>`.
+3. Tag the release commit with the printed command and push the tag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "seance-render-test"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "insta",
  "libghostty-vt",

--- a/crates/seance-app/build.rs
+++ b/crates/seance-app/build.rs
@@ -1,0 +1,35 @@
+//! Stamps the short git SHA into the binary as `SEANCE_GIT_SHA` so
+//! `seance --version` can print `séance <version> (<sha>)`. Falls back to
+//! `unknown` outside a git checkout (e.g. release tarball builds).
+
+use std::path::Path;
+use std::process::Command;
+
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
+fn main() {
+    let sha = git(&["rev-parse", "--short=7", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    println!("cargo::rustc-env=SEANCE_GIT_SHA={sha}");
+
+    // Re-stamp when HEAD moves: .git/HEAD changes on checkout/detach, and
+    // the branch ref file it points at changes on commit.
+    if let Some(git_dir) = git(&["rev-parse", "--absolute-git-dir"]) {
+        let head = Path::new(&git_dir).join("HEAD");
+        if head.exists() {
+            println!("cargo::rerun-if-changed={}", head.display());
+        }
+        if let Some(ref_name) = git(&["symbolic-ref", "-q", "HEAD"]) {
+            let ref_file = Path::new(&git_dir).join(ref_name);
+            if ref_file.exists() {
+                println!("cargo::rerun-if-changed={}", ref_file.display());
+            }
+        }
+    }
+}

--- a/crates/seance-app/src/main.rs
+++ b/crates/seance-app/src/main.rs
@@ -95,9 +95,21 @@ fn init_tracing() -> Option<WorkerGuard> {
 }
 
 fn main() {
+    if std::env::args()
+        .skip(1)
+        .any(|arg| arg == "--version" || arg == "-V")
+    {
+        println!(
+            "séance {} ({})",
+            env!("CARGO_PKG_VERSION"),
+            env!("SEANCE_GIT_SHA")
+        );
+        return;
+    }
     let _log_guard = init_tracing();
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
+        git_sha = env!("SEANCE_GIT_SHA"),
         log_dir = ?log_dir(),
         "seance starting",
     );

--- a/crates/seance-render-test/Cargo.toml
+++ b/crates/seance-render-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seance-render-test"
-version = "0.0.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tools/bump-version.sh
+++ b/tools/bump-version.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Bump the workspace version, roll CHANGELOG.md, refresh Cargo.lock, and
+# print the tag command. Never commits or pushes.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+usage() {
+    echo "usage: tools/bump-version.sh <new-version>" >&2
+    echo "  e.g. tools/bump-version.sh 0.2.0" >&2
+    exit 64
+}
+
+[ $# -eq 1 ] || usage
+new="$1"
+echo "$new" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$' || usage
+
+current="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+if [ "$new" = "$current" ]; then
+    echo "workspace version is already $current" >&2
+    exit 1
+fi
+
+# [workspace.package] holds the only top-level `version = "..."` key;
+# per-crate manifests inherit via `version.workspace = true`.
+tmp="$(mktemp)"
+awk -v new="$new" '
+    !done && /^version = "/ { print "version = \"" new "\""; done = 1; next }
+    { print }
+' Cargo.toml >"$tmp"
+mv "$tmp" Cargo.toml
+
+today="$(date +%Y-%m-%d)"
+tmp="$(mktemp)"
+awk -v ver="$new" -v date="$today" '
+    { print }
+    /^## \[Unreleased\]$/ { print ""; print "## [" ver "] - " date }
+' CHANGELOG.md >"$tmp"
+mv "$tmp" CHANGELOG.md
+
+cargo update --workspace --quiet
+
+echo "bumped $current -> $new"
+echo "next:"
+echo "  git commit -am \"chore(release): v$new\""
+echo "  git tag v$new"


### PR DESCRIPTION
Release-pipeline plumbing for Epic M9 (#152): one version source, a stamped binary for platform smoke tests, and a curated changelog, per the work items in #161.

What's here, and why it deviates where it does:

- `[workspace.package].version` was already the single source; the one holdout, `seance-render-test` (pinned `0.0.0`), now inherits it, so `cargo metadata` reports `0.1.0` for all eleven crates. `Cargo.lock` is refreshed accordingly.
- `crates/seance-app/build.rs` embeds the short git SHA as `SEANCE_GIT_SHA` via a tiny custom script instead of `vergen` — one external command, no new dependency. It falls back to `unknown` outside a checkout (release tarballs) and re-stamps when `.git/HEAD` or the checked-out branch ref moves.
- `seance --version` / `-V` prints `séance 0.1.0 (4b5408a)`-style output and exits 0 before any tracing, winit, or wgpu initialization, so it works without a display. The startup log line now carries the SHA too.
- `CHANGELOG.md` is seeded in Keep-a-Changelog form with `[Unreleased]` (carrying this PR's entry) and an empty `[0.1.0]` placeholder. `CONTRIBUTING.md` documents the semver scheme (0.x may break) and the release steps.
- The bump helper lives at `tools/bump-version.sh`, not the `scripts/` path in the issue, because every dev script in this repo lives under `tools/`. It rewrites only the workspace version key, rolls `[Unreleased]` into a dated section, runs `cargo update --workspace`, and prints the commit/tag commands without pushing.
- CI gains a `version` job gated on tag refs (push triggers now include `tags: ["v*"]`) that fails when the tag name disagrees with the workspace version. Comparing `GITHUB_REF_NAME` against the manifest is equivalent to `git describe --exact-match` on a tag-triggered run and avoids needing full fetch depth.

Verification: the build script was compiled and executed standalone (emits the correct SHA and rerun directives), the extracted `--version` path was compiled and run against both flags (prints `séance 0.1.0 (abc1234)`, exit 0), `tools/bump-version.sh 0.2.0` was dry-run end to end (correct manifest edit, changelog roll, and rejection of malformed/no-op versions), and `cargo fmt --check`, `prettier --check`, and `markdownlint-cli2` all pass. A full `cargo check` was not possible in this Linux container — zig is unavailable here for the `libghostty-vt-sys` build — so the workspace build/clippy/test gates ride on CI.

Closes #161

---
_Generated by [Claude Code](https://claude.ai/code/session_019uR5Gi2vdCRygeerkSqYAL)_