### PR TITLE
feat(config): add bold-is-bright option

### DIFF
--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -233,6 +233,7 @@ impl ApplicationHandler<UserEvent> for App {
             min_contrast: self.config.font.min_contrast,
             window_padding: physical_window_padding(&self.config, window.scale_factor()),
             background_opacity: self.config.window.background_opacity,
+            bold_is_bright: self.config.bold_is_bright,
             theme: theme.clone(),
         };
 

--- a/crates/seance-app/src/reload.rs
+++ b/crates/seance-app/src/reload.rs
@@ -82,6 +82,11 @@ impl App {
                     .renderer
                     .set_background_opacity(self.config.window.background_opacity);
             }
+            if old_config.bold_is_bright != self.config.bold_is_bright {
+                surface
+                    .renderer
+                    .set_bold_is_bright(self.config.bold_is_bright);
+            }
         }
 
         if diff.font_size_changed {

--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -38,8 +38,8 @@ pub struct ConfigDiff {
     /// `window.padding_x|y` changed — caller must push the new padding to
     /// the renderer and reflow the PTY (cols/rows shrink when padding grows).
     pub window_padding_changed: bool,
-    /// Min-contrast, cursor, or opacity changed — a plain repaint is
-    /// enough once the renderer has consumed the new values.
+    /// Min-contrast, cursor, opacity, or bold-is-bright changed — a plain
+    /// repaint is enough once the renderer has consumed the new values.
     pub repaint_only: bool,
     /// `[input]` section changed — caller must push the new settings to
     /// `InputHandler` (e.g. `macos_option_as_alt`).
@@ -75,7 +75,8 @@ impl ConfigDiff {
         let repaint_only = old.font.min_contrast != new.font.min_contrast
             || old.window.background_opacity != new.window.background_opacity
             || old.cursor.style != new.cursor.style
-            || old.cursor.blink != new.cursor.blink;
+            || old.cursor.blink != new.cursor.blink
+            || old.bold_is_bright != new.bold_is_bright;
 
         let input_changed = old.input.macos_option_as_alt != new.input.macos_option_as_alt;
         let links_changed = old.links != new.links;
@@ -222,6 +223,17 @@ mod tests {
         let d = ConfigDiff::between(&a, &b);
         assert!(d.window_padding_changed);
         assert!(!d.repaint_only);
+    }
+
+    #[test]
+    fn bold_is_bright_change_is_repaint_only() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.bold_is_bright = true;
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.repaint_only);
+        assert!(!d.theme_changed);
+        assert!(!d.font_size_changed);
     }
 
     #[test]

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -12,6 +12,10 @@ use serde::Deserialize;
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub theme: Option<String>,
+    /// SGR bold (1) remaps an ANSI 0–7 foreground to its bright 8–15 entry,
+    /// matching Ghostty's `bold-is-bright`. RGB and 256-color foregrounds are
+    /// untouched.
+    pub bold_is_bright: bool,
     pub font: FontConfig,
     pub window: WindowConfig,
     pub cursor: CursorConfig,
@@ -26,6 +30,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             theme: Some("Catppuccin Frappe".to_string()),
+            bold_is_bright: false,
             font: FontConfig::default(),
             window: WindowConfig::default(),
             cursor: CursorConfig::default(),

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -29,6 +29,8 @@ pub struct RendererConfig {
     /// fullscreen bg pass with the effective theme background.
     pub window_padding: [u16; 2],
     pub background_opacity: f32,
+    /// Remap ANSI 0–7 foregrounds to bright 8–15 on bold cells.
+    pub bold_is_bright: bool,
     pub theme: Theme,
 }
 
@@ -70,6 +72,7 @@ pub struct TerminalRenderer {
     surface_width: u32,
     surface_height: u32,
     window_padding: [u16; 2],
+    bold_is_bright: bool,
 }
 
 impl TerminalRenderer {
@@ -97,6 +100,7 @@ impl TerminalRenderer {
             surface_width: config.width,
             surface_height: config.height,
             window_padding: config.window_padding,
+            bold_is_bright: config.bold_is_bright,
         })
     }
 
@@ -170,6 +174,7 @@ impl TerminalRenderer {
                 theme: &self.theme,
                 bg_color,
                 min_contrast,
+                bold_is_bright: self.bold_is_bright,
             },
         );
         if let Some(fi) = self.cell_builder.last_frame() {
@@ -239,6 +244,12 @@ impl TerminalRenderer {
 
     pub fn set_min_contrast(&mut self, min_contrast: f32) {
         self.min_contrast = min_contrast.clamp(1.0, 21.0);
+    }
+
+    /// Toggle `bold-is-bright`. Consumed CPU-side during the next
+    /// `update_frame()`, so the caller only needs to trigger a repaint.
+    pub fn set_bold_is_bright(&mut self, bold_is_bright: bool) {
+        self.bold_is_bright = bold_is_bright;
     }
 
     pub fn set_background_opacity(&mut self, opacity: f32) {

--- a/crates/seance-render/src/text/cell_builder.rs
+++ b/crates/seance-render/src/text/cell_builder.rs
@@ -64,6 +64,7 @@ pub struct BuildFrameConfig<'a> {
     pub theme: &'a Theme,
     pub bg_color: [u8; 4],
     pub min_contrast: f32,
+    pub bold_is_bright: bool,
 }
 
 type GlyphSlots = HashMap<GlyphId, AtlasEntry, FxBuildHasher>;
@@ -237,6 +238,7 @@ impl CellBuilder {
             &mut self.bg_cells,
             &mut self.runs,
             &mut self.procedural_cells,
+            config.bold_is_bright,
         );
 
         self.text_cells.clear();
@@ -348,10 +350,17 @@ fn geometry(
 
 /// Resolve a VT-reported color into concrete RGB. `None` means "use the
 /// theme default" — the caller decides fg vs bg.
-fn resolve_color(theme: &Theme, color: &CellColor) -> Option<[u8; 3]> {
+///
+/// `brighten` applies the `bold-is-bright` remap: an ANSI 0–7 palette index is
+/// shifted to its bright 8–15 counterpart. It only ever makes sense on the
+/// foreground of a bold cell; RGB and 256-color (8+) entries are untouched.
+fn resolve_color(theme: &Theme, color: &CellColor, brighten: bool) -> Option<[u8; 3]> {
     match *color {
         CellColor::Default => None,
-        CellColor::Palette(idx) => Some(theme.palette[idx as usize]),
+        CellColor::Palette(idx) => {
+            let idx = if brighten && idx < 8 { idx + 8 } else { idx };
+            Some(theme.palette[idx as usize])
+        }
         CellColor::Rgb(r, g, b) => Some([r, g, b]),
     }
 }
@@ -368,6 +377,7 @@ fn walk_grid_into_runs(
     bg_cells: &mut Vec<[u8; 4]>,
     runs: &mut Vec<ShapeRun>,
     procedural_cells: &mut Vec<ProceduralCell>,
+    bold_is_bright: bool,
 ) {
     bg_cells.clear();
     bg_cells.resize(
@@ -385,6 +395,7 @@ fn walk_grid_into_runs(
         theme,
         cols: geom.grid_cols,
         rows: geom.grid_rows,
+        bold_is_bright,
     };
     source.visit_cells(&mut visitor);
     visitor.flush();
@@ -484,6 +495,7 @@ struct RunBuilder<'a> {
     theme: &'a Theme,
     cols: u16,
     rows: u16,
+    bold_is_bright: bool,
 }
 
 impl RunBuilder<'_> {
@@ -505,8 +517,9 @@ impl CellVisitor for RunBuilder<'_> {
 
         let theme_bg = [self.theme.bg[0], self.theme.bg[1], self.theme.bg[2]];
         let min_contrast = matches!(view.fg, CellColor::Default) && !view.attrs.inverse;
-        let mut fg_rgb = resolve_color(self.theme, &view.fg).unwrap_or(self.theme.fg);
-        let mut bg_rgb = resolve_color(self.theme, &view.bg).unwrap_or(theme_bg);
+        let brighten_fg = self.bold_is_bright && view.attrs.bold;
+        let mut fg_rgb = resolve_color(self.theme, &view.fg, brighten_fg).unwrap_or(self.theme.fg);
+        let mut bg_rgb = resolve_color(self.theme, &view.bg, false).unwrap_or(theme_bg);
         if view.attrs.inverse {
             std::mem::swap(&mut fg_rgb, &mut bg_rgb);
         }
@@ -743,6 +756,7 @@ mod tests {
             theme,
             bg_color: [0, 0, 0, 255],
             min_contrast: 1.0,
+            bold_is_bright: false,
         }
     }
 
@@ -767,6 +781,16 @@ mod tests {
         cells: &[FakeCell<'_>],
         theme: &Theme,
     ) -> (Vec<[u8; 4]>, Vec<ShapeRun>, Vec<ProceduralCell>) {
+        collect_runs_cfg(cols, rows, cells, theme, false)
+    }
+
+    fn collect_runs_cfg(
+        cols: u16,
+        rows: u16,
+        cells: &[FakeCell<'_>],
+        theme: &Theme,
+        bold_is_bright: bool,
+    ) -> (Vec<[u8; 4]>, Vec<ShapeRun>, Vec<ProceduralCell>) {
         let mut source = FakeFrame::new(cols, rows, cells);
         let geom = FrameGeometry {
             cell_width: 10.0,
@@ -785,6 +809,7 @@ mod tests {
             &mut bg,
             &mut runs,
             &mut procedural,
+            bold_is_bright,
         );
         (bg, runs, procedural)
     }
@@ -898,6 +923,58 @@ mod tests {
 
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].slots[0].fg, [0, 205, 205, FAINT_ALPHA]);
+    }
+
+    #[test]
+    fn bold_is_bright_remaps_ansi_fg_to_bright_for_bold_cells() {
+        let theme = Theme::blank();
+        let cells = [("B", CellColor::Palette(1), CellColor::Default, bold())];
+        let (_bg, runs, _) = collect_runs_cfg(1, 1, &cells, &theme, true);
+
+        assert_eq!(runs.len(), 1);
+        // Palette(1) (0xcd0000) brightens to Palette(9) (0xff0000).
+        assert_eq!(runs[0].slots[0].fg, [0xff, 0x00, 0x00, 255]);
+    }
+
+    #[test]
+    fn bold_is_bright_leaves_fg_untouched_when_disabled() {
+        let theme = Theme::blank();
+        let cells = [("B", CellColor::Palette(1), CellColor::Default, bold())];
+        let (_bg, runs, _) = collect_runs_cfg(1, 1, &cells, &theme, false);
+
+        assert_eq!(runs[0].slots[0].fg, [0xcd, 0x00, 0x00, 255]);
+    }
+
+    #[test]
+    fn bold_is_bright_only_brightens_bold_cells() {
+        let theme = Theme::blank();
+        let cells = [("p", CellColor::Palette(1), CellColor::Default, plain())];
+        let (_bg, runs, _) = collect_runs_cfg(1, 1, &cells, &theme, true);
+
+        assert_eq!(runs[0].slots[0].fg, [0xcd, 0x00, 0x00, 255]);
+    }
+
+    #[test]
+    fn bold_is_bright_leaves_high_palette_and_rgb_fg_alone() {
+        let theme = Theme::blank();
+        let cells = [
+            // Already-bright ANSI index (9) stays put — no wrap past 15.
+            ("a", CellColor::Palette(9), CellColor::Default, bold()),
+            ("b", CellColor::Rgb(10, 20, 30), CellColor::Default, bold()),
+        ];
+        let (_bg, runs, _) = collect_runs_cfg(2, 1, &cells, &theme, true);
+
+        assert_eq!(runs[0].slots[0].fg, [0xff, 0x00, 0x00, 255]);
+        assert_eq!(runs[0].slots[1].fg, [10, 20, 30, 255]);
+    }
+
+    #[test]
+    fn bold_is_bright_never_brightens_background() {
+        let theme = Theme::blank();
+        let cells = [("x", CellColor::Default, CellColor::Palette(1), bold())];
+        let (bg, _runs, _) = collect_runs_cfg(1, 1, &cells, &theme, true);
+
+        assert_eq!(bg[0], [0xcd, 0x00, 0x00, 255]);
     }
 
     #[test]


### PR DESCRIPTION
Adds a top-level `bold_is_bright` config key mirroring Ghostty's [`bold-is-bright`](https://ghostty.org/docs/config/reference#bold-is-bright). When enabled, a bold cell whose foreground is an ANSI 0–7 palette color is remapped to its bright 8–15 counterpart. RGB and 256-color foregrounds, backgrounds, and non-bold cells are left untouched, so the default (`false`) is a no-op and existing rendering is unchanged.

The remap lives where it belongs: CPU-side in `seance-render`'s `cell_builder` color resolution, right next to the existing inverse/faint handling. `resolve_color` grows a `brighten` flag (passed only for the foreground of bold cells), and the flag threads through `BuildFrameConfig` → `RunBuilder` and through the renderer's `RendererConfig`/`TerminalRenderer`. Doing it here rather than in the shader keeps it consistent with how the rest of seance resolves SGR colors and means it reflows automatically through the existing dirty/repaint path.

Hot reload treats the key like min-contrast and opacity: it folds into the `repaint_only` diff bucket, and `reload_config` pushes the new value via `TerminalRenderer::set_bold_is_bright` before triggering a repaint. Because the flag is consumed at frame-build time, no cache or GPU buffer needs touching.

Tested with unit coverage in `seance-config` (diff classification) and `seance-render` (bright remap for bold ANSI fg, no-op when disabled, no-op for non-bold cells, already-bright/RGB foregrounds untouched, and backgrounds never brightened). `cargo fmt --check`, `cargo clippy -D warnings`, and the `seance-config`/`seance-render` test suites pass locally. The `seance-app` plumbing (one `RendererConfig` field and the reload hook) could not be compiled in this Linux container because `libghostty-vt-sys` requires `zig`, which is unavailable here, so that crate's build/clippy/test ride on CI.

Closes #175


---
_Generated by [Claude Code](https://claude.ai/code/session_012ieTbSVnt6aLMY1HS5UHgj)_