### PR TITLE
fix(render): straddle bar cursor across the cell boundary

### DIFF
--- a/crates/seance-render/src/gpu/shaders/cell.wgsl
+++ b/crates/seance-render/src/gpu/shaders/cell.wgsl
@@ -203,9 +203,17 @@ fn fs_cell_bg(in: FullScreenOut) -> @location(0) vec4<f32> {
         color = vec4<f32>(sel.rgb, 1.0);
     }
 
+    let on_cursor_col = col == uniforms.overlay_pos.x;
+    // The bar cursor straddles the left edge of its cell, so half of it spills
+    // into the preceding cell. Guard column 0 (nothing to the left to straddle
+    // into — that outer half is simply clipped, matching ghostty).
+    let on_bar_prev_col = uniforms.overlay_shape == 3u
+                       && uniforms.overlay_pos.x > 0u
+                       && col == uniforms.overlay_pos.x - 1u;
+
     if uniforms.cursor_visible != 0u
        && uniforms.overlay_shape != 0u
-       && col == uniforms.overlay_pos.x
+       && (on_cursor_col || on_bar_prev_col)
        && row == uniforms.overlay_pos.y {
         let local = pos - uniforms.cell_size * vec2<f32>(f32(col), f32(row));
         let cur_color = uniforms.overlay_color;
@@ -218,7 +226,14 @@ fn fs_cell_bg(in: FullScreenOut) -> @location(0) vec4<f32> {
             draw = local.y >= (uniforms.cell_size.y - thickness);
         } else if uniforms.overlay_shape == 3u {
             let thickness = max(2.0, uniforms.cell_size.x * 0.1);
-            draw = local.x < thickness;
+            let half = thickness * 0.5;
+            if on_cursor_col {
+                // Inner half: against the left edge inside the cursor cell.
+                draw = local.x < half;
+            } else {
+                // Outer half: against the right edge of the preceding cell.
+                draw = local.x >= (uniforms.cell_size.x - half);
+            }
         }
 
         if draw {


### PR DESCRIPTION
Ghostty places the bar cursor with half its thickness over the left edge of the cell, so it "sits centered between characters, not biased to a side" (`src/font/sprite/draw/special.zig`). Seance instead drew the whole bar inside the cursor cell (`local.x < thickness` in `fs_cell_bg`), biasing it to the right of the boundary.

This fixes the bar geometry in `crates/seance-render/src/gpu/shaders/cell.wgsl`:

- The cell-background overlay gate now also arms for the cell immediately to the left of the cursor, but only when the overlay shape is a bar. Block and underline shapes keep matching the cursor cell alone, so they are visually unchanged.
- The bar draw is split into two halves around the shared edge: the inner half hugs the left edge inside the cursor cell (`local.x < thickness/2`) and the outer half hugs the right edge of the preceding cell (`local.x >= cell_size.x - thickness/2`). The combined width equals the existing thickness, now centered on the boundary.
- Column 0 is guarded: with no cell to the left, the outer half is simply clipped, matching ghostty's behavior at the row start.

Thickness is left as the existing `max(2.0, cell_size.x * 0.1)`. The issue notes that piping a font-derived `cursor_thickness` uniform (so width stops scaling with cell width) is an optional, separate improvement; it is deliberately out of scope here to keep the change to the straddle geometry and avoid app-side uniform plumbing.

The WGSL was parsed and validated with naga (the version wgpu pulls in) since shader compilation otherwise only happens at GPU pipeline creation. `cargo fmt --check`, `cargo clippy -p seance-render --all-targets -D warnings`, and `cargo test -p seance-render` all pass locally.

Closes #182

---
_Generated by [Claude Code](https://claude.ai/code/session_013MVvedXvPq1acsdTUtyuUq)_