### PR TITLE
feat(config): add window.padding_balance for symmetric padding

### DIFF
--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -232,6 +232,7 @@ impl ApplicationHandler<UserEvent> for App {
             font_features: self.config.font.features.clone(),
             min_contrast: self.config.font.min_contrast,
             window_padding: physical_window_padding(&self.config, window.scale_factor()),
+            window_padding_balance: self.config.window.padding_balance,
             background_opacity: self.config.window.background_opacity,
             theme: theme.clone(),
         };

--- a/crates/seance-app/src/apply.rs
+++ b/crates/seance-app/src/apply.rs
@@ -38,9 +38,11 @@ impl App {
 
     pub(crate) fn apply_scale_factor(&mut self, scale_factor: f64) {
         let padding = physical_window_padding(&self.config, scale_factor);
+        let balance = self.config.window.padding_balance;
         if let Some(ws) = self.surface_mut() {
             ws.renderer.set_scale(scale_factor);
             ws.renderer.set_window_padding(padding);
+            ws.renderer.set_window_padding_balance(balance);
             ws.reflow(ws.window.inner_size());
         }
     }
@@ -53,6 +55,8 @@ impl App {
         if let Some(ws) = self.surface.as_mut() {
             let padding = physical_window_padding(config, ws.window.scale_factor());
             ws.renderer.set_window_padding(padding);
+            ws.renderer
+                .set_window_padding_balance(config.window.padding_balance);
             ws.reflow(ws.window.inner_size());
         }
     }

--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -67,7 +67,8 @@ impl ConfigDiff {
         let font_features_changed = old.font.features != new.font.features;
 
         let window_padding_changed = old.window.padding_x != new.window.padding_x
-            || old.window.padding_y != new.window.padding_y;
+            || old.window.padding_y != new.window.padding_y
+            || old.window.padding_balance != new.window.padding_balance;
 
         // Fields whose consumers will pick up changes on the next paint.
         // Grouped together so we can request a single redraw if any of them
@@ -222,6 +223,15 @@ mod tests {
         let d = ConfigDiff::between(&a, &b);
         assert!(d.window_padding_changed);
         assert!(!d.repaint_only);
+    }
+
+    #[test]
+    fn padding_balance_toggle_sets_window_padding_flag() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.window.padding_balance = !a.window.padding_balance;
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.window_padding_changed);
     }
 
     #[test]

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -78,6 +78,10 @@ impl Default for FontConfig {
 pub struct WindowConfig {
     pub padding_x: u16,
     pub padding_y: u16,
+    // When the surface can't divide evenly into whole cells, distribute the
+    // leftover pixels symmetrically around the grid instead of dumping the
+    // remainder on the right/bottom edges.
+    pub padding_balance: bool,
     pub decoration: bool,
     pub background_opacity: f32,
 }
@@ -87,6 +91,7 @@ impl Default for WindowConfig {
         Self {
             padding_x: 12,
             padding_y: 0,
+            padding_balance: false,
             decoration: true,
             background_opacity: 1.0,
         }

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -28,6 +28,9 @@ pub struct RendererConfig {
     /// pixels. `[x, y]`. The area outside the grid is filled by the
     /// fullscreen bg pass with the effective theme background.
     pub window_padding: [u16; 2],
+    /// Distribute the sub-cell remainder symmetrically around the grid rather
+    /// than leaving it all on the right/bottom edges.
+    pub window_padding_balance: bool,
     pub background_opacity: f32,
     pub theme: Theme,
 }
@@ -70,6 +73,7 @@ pub struct TerminalRenderer {
     surface_width: u32,
     surface_height: u32,
     window_padding: [u16; 2],
+    window_padding_balance: bool,
 }
 
 impl TerminalRenderer {
@@ -97,6 +101,7 @@ impl TerminalRenderer {
             surface_width: config.width,
             surface_height: config.height,
             window_padding: config.window_padding,
+            window_padding_balance: config.window_padding_balance,
         })
     }
 
@@ -167,6 +172,7 @@ impl TerminalRenderer {
                 surface_width: self.surface_width,
                 surface_height: self.surface_height,
                 window_padding: self.window_padding,
+                window_padding_balance: self.window_padding_balance,
                 theme: &self.theme,
                 bg_color,
                 min_contrast,
@@ -250,6 +256,10 @@ impl TerminalRenderer {
     /// new cols/rows to the PTY.
     pub fn set_window_padding(&mut self, padding: [u16; 2]) {
         self.window_padding = padding;
+    }
+
+    pub fn set_window_padding_balance(&mut self, balance: bool) {
+        self.window_padding_balance = balance;
     }
 
     fn effective_bg_color(&self) -> [u8; 4] {

--- a/crates/seance-render/src/text/cell_builder.rs
+++ b/crates/seance-render/src/text/cell_builder.rs
@@ -61,6 +61,7 @@ pub struct BuildFrameConfig<'a> {
     pub surface_width: u32,
     pub surface_height: u32,
     pub window_padding: [u16; 2],
+    pub window_padding_balance: bool,
     pub theme: &'a Theme,
     pub bg_color: [u8; 4],
     pub min_contrast: f32,
@@ -225,6 +226,7 @@ impl CellBuilder {
                 config.surface_width,
                 config.surface_height,
                 config.window_padding,
+                config.window_padding_balance,
             );
             (m.baseline, g)
         };
@@ -323,26 +325,41 @@ fn geometry(
     surface_width: u32,
     surface_height: u32,
     window_padding: [u16; 2],
+    balance: bool,
 ) -> FrameGeometry {
     let (cols, rows) = source.grid_size();
-    // User-configured padding anchors the grid at `(padding_x, padding_y)`.
-    // Any residual between the grid pixel extent and the surface is left on
-    // the right/bottom and filled by the fullscreen bg pass — matches
-    // Ghostty/Alacritty semantics (padding = minimum gutter, not centering).
+    // User-configured padding is the minimum gutter and anchors the grid at
+    // `(padding_x, padding_y)`. The sub-cell residual between the grid pixel
+    // extent and the surface is filled by the fullscreen bg pass: left on the
+    // right/bottom edges by default (Ghostty/Alacritty semantics), or split
+    // evenly around the grid when `padding_balance` is set.
+    let grid_w = cols as f32 * cell_width;
+    let grid_h = rows as f32 * cell_height;
     let user_pad_x = f32::from(window_padding[0]);
     let user_pad_y = f32::from(window_padding[1]);
     let pad_x = user_pad_x
-        .min((surface_width as f32 - cols as f32 * cell_width).max(0.0))
+        .min((surface_width as f32 - grid_w).max(0.0))
         .max(0.0);
     let pad_y = user_pad_y
-        .min((surface_height as f32 - rows as f32 * cell_height).max(0.0))
+        .min((surface_height as f32 - grid_h).max(0.0))
         .max(0.0);
+    // `padding_balance`: split the sub-cell remainder beyond the two gutters
+    // evenly so the grid is centered instead of flush to the top-left.
+    let (extra_x, extra_y) = if balance {
+        let leftover_x = (surface_width as f32 - grid_w - 2.0 * pad_x).max(0.0);
+        let leftover_y = (surface_height as f32 - grid_h - 2.0 * pad_y).max(0.0);
+        (leftover_x / 2.0, leftover_y / 2.0)
+    } else {
+        (0.0, 0.0)
+    };
+    let left = pad_x + extra_x;
+    let top = pad_y + extra_y;
     FrameGeometry {
         cell_width,
         cell_height,
         grid_cols: cols,
         grid_rows: rows,
-        grid_padding: [pad_x, pad_y, pad_x, pad_y],
+        grid_padding: [left, top, left, top],
     }
 }
 
@@ -740,6 +757,7 @@ mod tests {
             surface_width: 100,
             surface_height: 100,
             window_padding: [0, 0],
+            window_padding_balance: false,
             theme,
             bg_color: [0, 0, 0, 255],
             min_contrast: 1.0,
@@ -843,7 +861,7 @@ mod tests {
     fn geometry_honors_user_padding() {
         let cells: [FakeCell<'_>; 0] = [];
         let mut source = FakeFrame::new(10, 5, &cells);
-        let g = geometry(&mut source, 10.0, 20.0, 200, 200, [12, 6]);
+        let g = geometry(&mut source, 10.0, 20.0, 200, 200, [12, 6], false);
         assert_eq!(g.grid_padding, [12.0, 6.0, 12.0, 6.0]);
     }
 
@@ -851,9 +869,29 @@ mod tests {
     fn geometry_clamps_padding_to_surface() {
         let cells: [FakeCell<'_>; 0] = [];
         let mut source = FakeFrame::new(10, 5, &cells);
-        let g = geometry(&mut source, 10.0, 20.0, 110, 110, [50, 40]);
+        let g = geometry(&mut source, 10.0, 20.0, 110, 110, [50, 40], false);
         assert_eq!(g.grid_padding[0], 10.0);
         assert_eq!(g.grid_padding[1], 10.0);
+    }
+
+    #[test]
+    fn geometry_unbalanced_leaves_remainder_on_far_edge() {
+        // 10×5 grid at 10×20 px = 100×100 grid in a 150×150 surface, pad 12.
+        // Without balancing the grid stays anchored at the user padding.
+        let cells: [FakeCell<'_>; 0] = [];
+        let mut source = FakeFrame::new(10, 5, &cells);
+        let g = geometry(&mut source, 10.0, 20.0, 150, 150, [12, 12], false);
+        assert_eq!(g.grid_padding, [12.0, 12.0, 12.0, 12.0]);
+    }
+
+    #[test]
+    fn geometry_balance_centers_the_remainder() {
+        // Same geometry: leftover beyond the gutters is 150 - 100 - 24 = 26,
+        // split as 13 on each side, so the grid origin shifts to 12 + 13.
+        let cells: [FakeCell<'_>; 0] = [];
+        let mut source = FakeFrame::new(10, 5, &cells);
+        let g = geometry(&mut source, 10.0, 20.0, 150, 150, [12, 12], true);
+        assert_eq!(g.grid_padding, [25.0, 25.0, 25.0, 25.0]);
     }
 
     // ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Ghostty's [`window-padding-balance`](https://ghostty.org/docs/config/reference#window-padding-balance) distributes the sub-cell remainder symmetrically around the content block when the surface dimensions can't divide evenly into whole cells. Seance had no schema field for this and the renderer left the remainder flush on the right/bottom edges, so there was no way to center the grid.

This adds a top-level `window.padding_balance` bool (default `false`, so the existing flush-top-left layout is unchanged). When enabled, `geometry` in `seance-render`'s `cell_builder` splits the leftover pixels beyond the two configured gutters evenly and folds half into the left/top padding, centering the grid; the right/bottom mouse-padding values track the same offset so hit-testing stays correct.

The flag threads through the established config plumbing: `WindowConfig` → `RendererConfig` → `TerminalRenderer` → `BuildFrameConfig` → `geometry`. Hot reload reuses the existing `window_padding` diff bucket — `ConfigDiff` now flips `window_padding_changed` when `padding_balance` toggles, and `apply_window_padding`/`apply_scale_factor` push the flag via the new `set_window_padding_balance` setter before reflowing and repainting, so the change takes effect without a restart.

Because it is consumed at frame-build time, no GPU buffer or cache needs touching, and a disabled (default) config is a pixel-identical no-op.

## Testing

New unit coverage: `geometry_unbalanced_leaves_remainder_on_far_edge` and `geometry_balance_centers_the_remainder` pin the origin math both ways, and `padding_balance_toggle_sets_window_padding_flag` covers the diff classification. `cargo fmt --check`, `cargo clippy -p seance-config -p seance-render --all-targets -D warnings`, and the `seance-config`/`seance-render` test suites pass locally. `seance-app` (the two `apply_*` hooks and the `RendererConfig` field) could not be compiled in this Linux container because `libghostty-vt-sys` needs `zig`, which is unavailable here, so that crate's build/clippy/test ride on CI.

Closes #176

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcE6kqPUfwjoEmhNhvASi3)_