### PR TITLE
feat(config): add font.thicken faux-bold toggle

### DIFF
--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -231,6 +231,7 @@ impl ApplicationHandler<UserEvent> for App {
             adjust_cell_width: self.config.font.adjust_cell_width.clone(),
             font_features: self.config.font.features.clone(),
             min_contrast: self.config.font.min_contrast,
+            thicken: self.config.font.thicken,
             window_padding: physical_window_padding(&self.config, window.scale_factor()),
             background_opacity: self.config.window.background_opacity,
             theme: theme.clone(),

--- a/crates/seance-app/src/reload.rs
+++ b/crates/seance-app/src/reload.rs
@@ -105,6 +105,12 @@ impl App {
                 .set_font_features(&self.config.font.features);
             surface.mark_dirty();
         }
+        if diff.font_thicken_changed
+            && let Some(surface) = self.surface.as_mut()
+        {
+            surface.renderer.set_thicken(self.config.font.thicken);
+            surface.mark_dirty();
+        }
         if diff.font_family_changed {
             tracing::info!(
                 "font.family change takes effect on restart (live swap not yet supported)"

--- a/crates/seance-config/src/diff.rs
+++ b/crates/seance-config/src/diff.rs
@@ -35,6 +35,9 @@ pub struct ConfigDiff {
     /// `font.features` changed — caller must invalidate shape caches and
     /// rebuild the next frame.
     pub font_features_changed: bool,
+    /// `font.thicken` changed — caller must drop the glyph atlas so glyphs
+    /// re-rasterize with the new faux-bold setting and rebuild the next frame.
+    pub font_thicken_changed: bool,
     /// `window.padding_x|y` changed — caller must push the new padding to
     /// the renderer and reflow the PTY (cols/rows shrink when padding grows).
     pub window_padding_changed: bool,
@@ -65,6 +68,7 @@ impl ConfigDiff {
         let font_adjust_cell_width_changed =
             old.font.adjust_cell_width != new.font.adjust_cell_width;
         let font_features_changed = old.font.features != new.font.features;
+        let font_thicken_changed = old.font.thicken != new.font.thicken;
 
         let window_padding_changed = old.window.padding_x != new.window.padding_x
             || old.window.padding_y != new.window.padding_y;
@@ -89,6 +93,7 @@ impl ConfigDiff {
             font_adjust_cell_height_changed,
             font_adjust_cell_width_changed,
             font_features_changed,
+            font_thicken_changed,
             window_padding_changed,
             repaint_only,
             input_changed,
@@ -106,6 +111,7 @@ impl ConfigDiff {
             || self.font_adjust_cell_height_changed
             || self.font_adjust_cell_width_changed
             || self.font_features_changed
+            || self.font_thicken_changed
             || self.window_padding_changed
             || self.repaint_only
             || self.input_changed
@@ -190,6 +196,18 @@ mod tests {
         let d = ConfigDiff::between(&a, &b);
         assert!(d.font_features_changed);
         assert!(!d.font_size_changed);
+    }
+
+    #[test]
+    fn font_thicken_change_is_detected() {
+        let a = Config::default();
+        let mut b = Config::default();
+        b.font.thicken = true;
+        let d = ConfigDiff::between(&a, &b);
+        assert!(d.font_thicken_changed);
+        assert!(!d.font_features_changed);
+        assert!(!d.repaint_only);
+        assert!(!d.is_empty());
     }
 
     #[test]

--- a/crates/seance-config/src/schema.rs
+++ b/crates/seance-config/src/schema.rs
@@ -58,6 +58,10 @@ pub struct FontConfig {
     pub adjust_cell_height: Option<String>,
     pub adjust_cell_width: Option<String>,
     pub min_contrast: f32,
+    /// Faux-bold the rasterized glyph by dilating its coverage one pixel,
+    /// mirroring Ghostty's `font-thicken`. Applies to grayscale glyphs only;
+    /// color glyphs (emoji) are left untouched.
+    pub thicken: bool,
 }
 
 impl Default for FontConfig {
@@ -69,6 +73,7 @@ impl Default for FontConfig {
             adjust_cell_height: None,
             adjust_cell_width: None,
             min_contrast: 1.0,
+            thicken: false,
         }
     }
 }

--- a/crates/seance-render/src/renderer.rs
+++ b/crates/seance-render/src/renderer.rs
@@ -24,6 +24,8 @@ pub struct RendererConfig {
     /// "ss01", …). Empty means the shaper applies its own defaults.
     pub font_features: Vec<String>,
     pub min_contrast: f32,
+    /// Faux-bold every grayscale glyph (Ghostty's `font-thicken`).
+    pub thicken: bool,
     /// Inner gutter between window edges and the cell grid, in physical
     /// pixels. `[x, y]`. The area outside the grid is filled by the
     /// fullscreen bg pass with the effective theme background.
@@ -81,6 +83,7 @@ impl TerminalRenderer {
             adjust_cell_height: config.adjust_cell_height.as_deref(),
             adjust_cell_width: config.adjust_cell_width.as_deref(),
             features: &config.font_features,
+            thicken: config.thicken,
         }));
         let m = backend.metrics();
         let cell_size = [m.cell_width, m.cell_height];
@@ -227,6 +230,13 @@ impl TerminalRenderer {
     /// resolve to different glyphs under the new feature set.
     pub fn set_font_features(&mut self, features: &[String]) {
         self.backend.set_features(features);
+        self.cell_builder.reset_glyphs();
+    }
+
+    /// Toggle faux-bold. The glyph atlas is dropped because each glyph
+    /// re-rasterizes to a different coverage bitmap under the new setting.
+    pub fn set_thicken(&mut self, thicken: bool) {
+        self.backend.set_thicken(thicken);
         self.cell_builder.reset_glyphs();
     }
 

--- a/crates/seance-render/src/text/backend.rs
+++ b/crates/seance-render/src/text/backend.rs
@@ -88,6 +88,11 @@ pub trait TextBackend {
     /// can map to different glyphs once features change.
     fn set_features(&mut self, features: &[String]);
 
+    /// Toggle faux-bold (Ghostty's `font-thicken`). Callers must drop their
+    /// glyph atlas; the same glyph re-rasterizes to a different coverage
+    /// bitmap once thickening flips.
+    fn set_thicken(&mut self, thicken: bool);
+
     /// Shape a contiguous run of text into glyphs. Each emitted glyph
     /// carries the byte offset of its source cluster within `text`, so
     /// callers driving multi-cell input (ligatures, ZWJ sequences, flag

--- a/crates/seance-render/src/text/cell_builder.rs
+++ b/crates/seance-render/src/text/cell_builder.rs
@@ -719,6 +719,7 @@ mod tests {
         fn set_adjust_cell_height(&mut self, _value: Option<&str>) {}
         fn set_adjust_cell_width(&mut self, _value: Option<&str>) {}
         fn set_features(&mut self, _features: &[String]) {}
+        fn set_thicken(&mut self, _thicken: bool) {}
         fn shape_run(&mut self, text: &str, _attrs: FontAttrs, out: &mut Vec<ShapedGlyph>) {
             self.shape_calls += 1;
             let mut byte_offset = 0u32;
@@ -1159,6 +1160,7 @@ mod tests {
         fn set_adjust_cell_height(&mut self, _: Option<&str>) {}
         fn set_adjust_cell_width(&mut self, _: Option<&str>) {}
         fn set_features(&mut self, _: &[String]) {}
+        fn set_thicken(&mut self, _: bool) {}
         fn shape_run(&mut self, text: &str, _: FontAttrs, out: &mut Vec<ShapedGlyph>) {
             let mut byte = 0u32;
             for c in text.chars() {
@@ -1243,6 +1245,7 @@ mod tests {
         fn set_adjust_cell_height(&mut self, _: Option<&str>) {}
         fn set_adjust_cell_width(&mut self, _: Option<&str>) {}
         fn set_features(&mut self, _: &[String]) {}
+        fn set_thicken(&mut self, _: bool) {}
         fn shape_run(&mut self, text: &str, _: FontAttrs, out: &mut Vec<ShapedGlyph>) {
             if text == "==" {
                 out.push(ShapedGlyph {

--- a/crates/seance-render/src/text/cosmic.rs
+++ b/crates/seance-render/src/text/cosmic.rs
@@ -44,6 +44,8 @@ pub struct BackendConfig<'a> {
     /// not exactly four bytes are dropped with a warning so a typo can't
     /// silently disable shaping.
     pub features: &'a [String],
+    /// Faux-bold every grayscale glyph by dilating its coverage one pixel.
+    pub thicken: bool,
 }
 
 pub struct CosmicTextBackend {
@@ -58,6 +60,7 @@ pub struct CosmicTextBackend {
     /// Pre-built feature list passed to every shape call. Rebuilt only on
     /// `set_features` to avoid the per-shape parse cost.
     font_features: FontFeatures,
+    thicken: bool,
 
     /// Intern CacheKey → stable `GlyphId` so the atlas cache can key on
     /// a small integer without knowing the cosmic-text encoding.
@@ -88,6 +91,7 @@ impl CosmicTextBackend {
             adjust_cell_height,
             adjust_cell_width,
             font_features: build_font_features(config.features),
+            thicken: config.thicken,
             key_to_id: HashMap::with_hasher(FxBuildHasher),
             id_to_key: Vec::new(),
         }
@@ -152,6 +156,10 @@ impl TextBackend for CosmicTextBackend {
         self.font_features = build_font_features(features);
     }
 
+    fn set_thicken(&mut self, thicken: bool) {
+        self.thicken = thicken;
+    }
+
     fn shape_run(&mut self, text: &str, attrs: FontAttrs, out: &mut Vec<ShapedGlyph>) {
         if text.is_empty() {
             return;
@@ -204,9 +212,28 @@ impl TextBackend for CosmicTextBackend {
 
     fn rasterize(&mut self, glyph: GlyphId) -> Option<RasterizedGlyph> {
         let key = *self.id_to_key.get(glyph.0 as usize)?;
+        let thicken = self.thicken;
         let image = self.swash.get_image(&mut self.fs, key).as_ref()?;
         if image.placement.width == 0 || image.placement.height == 0 {
             return None;
+        }
+        let format = match image.content {
+            SwashContent::Color => GlyphFormat::Color,
+            _ => GlyphFormat::Alpha,
+        };
+        // Color glyphs (emoji) are left untouched — dilating premultiplied
+        // RGBA coverage would smear color, not bolden.
+        if thicken && format == GlyphFormat::Alpha {
+            let (data, width) =
+                embolden_alpha(&image.data, image.placement.width, image.placement.height);
+            return Some(RasterizedGlyph {
+                data,
+                width,
+                height: image.placement.height,
+                bearing_x: image.placement.left,
+                bearing_y: image.placement.top,
+                format,
+            });
         }
         Some(RasterizedGlyph {
             data: image.data.clone(),
@@ -214,12 +241,30 @@ impl TextBackend for CosmicTextBackend {
             height: image.placement.height,
             bearing_x: image.placement.left,
             bearing_y: image.placement.top,
-            format: match image.content {
-                SwashContent::Color => GlyphFormat::Color,
-                _ => GlyphFormat::Alpha,
-            },
+            format,
         })
     }
+}
+
+/// Faux-bold a single-byte-per-pixel coverage bitmap by widening every
+/// stroke one pixel to the right: each output column takes the max of itself
+/// and the column to its left. The bitmap grows one column wider while the
+/// left bearing is unchanged, matching the classic FreeType bitmap embolden.
+fn embolden_alpha(data: &[u8], width: u32, height: u32) -> (Vec<u8>, u32) {
+    let w = width as usize;
+    let h = height as usize;
+    let out_w = w + 1;
+    let mut out = vec![0u8; out_w * h];
+    for y in 0..h {
+        let src = &data[y * w..y * w + w];
+        let dst = &mut out[y * out_w..(y + 1) * out_w];
+        for x in 0..out_w {
+            let cur = if x < w { src[x] } else { 0 };
+            let left = if x > 0 { src[x - 1] } else { 0 };
+            dst[x] = cur.max(left);
+        }
+    }
+    (out, out_w as u32)
 }
 
 fn parse_metric_modifier(value: Option<&str>) -> Option<MetricModifier> {
@@ -399,6 +444,28 @@ fn build_font_features(features: &[String]) -> FontFeatures {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn embolden_widens_bitmap_one_column() {
+        // 3x2 coverage with a single lit column in the middle.
+        let src = vec![
+            0, 255, 0, //
+            0, 255, 0,
+        ];
+        let (out, width) = embolden_alpha(&src, 3, 2);
+        assert_eq!(width, 4);
+        // The lit stroke now spans two columns (its own plus the one to its
+        // right); the bitmap is one column wider and the left edge is fixed.
+        assert_eq!(out, vec![0, 255, 255, 0, 0, 255, 255, 0]);
+    }
+
+    #[test]
+    fn embolden_keeps_max_coverage_at_edges() {
+        let src = vec![255, 0, 0];
+        let (out, width) = embolden_alpha(&src, 3, 1);
+        assert_eq!(width, 4);
+        assert_eq!(out, vec![255, 255, 0, 0]);
+    }
 
     #[test]
     fn parses_metric_modifier_like_ghostty() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,8 @@ without libghostty linked. The local-mode binary pairs `seance-mux-client`
 - **OpenType features** [IMPLEMENTED] — `font.features` is parsed into a
   cosmic-text `FontFeatures` list and applied via `Attrs::font_features`.
 - **SwashCache** [IMPLEMENTED] — rasterizes outlines (COLR v0/v1, SVG, CBDT).
+  When `font.thicken` is set, grayscale coverage is dilated one pixel
+  (FreeType-style faux-bold) before atlas insertion; color glyphs are untouched.
 - **GlyphAtlas** [IMPLEMENTED] — two planes: grayscale R8 (2048×2048) and color
   RGBA8 (1024×1024). `etagere` rectangle packing, per-plane `dirty` flag.
 - **GlyphCache** [IMPLEMENTED] — `FxHashMap<cosmic_text::CacheKey, AtlasEntry>`.


### PR DESCRIPTION
Ghostty's [`font-thicken`](https://ghostty.org/docs/config/reference#font-thicken) bold-weight faux-bolding knob had no seance schema field. This adds a top-level `font.thicken` bool (default `false`, so the existing rendering is a pixel-identical no-op) and wires it through the glyph rasterizer, per epic #4 (M1 config & theme foundations).

The thickening is applied CPU-side in `CosmicTextBackend::rasterize`: when enabled, a grayscale glyph's coverage bitmap is dilated one pixel to the right — each output column takes the max of itself and its left neighbour, the classic FreeType-style bitmap embolden. The bitmap grows one column wider while the left bearing is unchanged. Color glyphs (emoji) are deliberately left untouched, since dilating premultiplied RGBA coverage would smear color rather than bolden.

The flag threads through the established config plumbing: `FontConfig` → `RendererConfig` → `BackendConfig`, with a `TerminalRenderer::set_thicken` setter that drops the glyph atlas (via the existing `reset_glyphs`) so glyphs re-rasterize under the new setting. Hot reload classifies the key as `font_thicken_changed` and calls the setter before marking the surface dirty, mirroring how `font.features` is handled — no GPU buffer or uniform needs touching.

## Testing

New unit coverage: `embolden_widens_bitmap_one_column` and `embolden_keeps_max_coverage_at_edges` pin the dilation math in `seance-render`, and `font_thicken_change_is_detected` covers the diff classification in `seance-config`. `cargo fmt --check`, `cargo clippy -p seance-config -p seance-render --all-targets -D warnings`, and the `seance-config`/`seance-render` test suites pass locally, as do `prettier --check` and `markdownlint-cli2` on the touched doc. The `seance-app` plumbing (one `RendererConfig` field and the reload hook) could not be compiled in this Linux container because `libghostty-vt-sys` requires `zig`, which is unavailable here, so that crate's build/clippy/test ride on CI.

Closes #174

---
_Generated by [Claude Code](https://claude.ai/code/session_017aKHB8QN9MKTQaiRPRjQgU)_