### PR TITLE
docs(naming): codify séance vs seance rule and fix drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
           node-version: "22"
       - run: npx --yes prettier --check "**/*.md"
 
+  naming:
+    name: naming
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: tools/check-naming.sh
+
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# seance
+# séance
 
 GPU-rendered terminal built on `libghostty-vt` (the Rust bindings from
 [libghostty-rs](https://github.com/Uzaaft/libghostty-rs)) and `wgpu`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ tools/run.sh                 # build and launch
 
 - Architecture & subsystem status:
   [`docs/architecture.md`](docs/architecture.md)
+- Naming (`séance` vs `seance`): [`docs/naming.md`](docs/naming.md)
 - Roadmap: GitHub epics M1–M11 (`label:epic`)
 
 ## License

--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -194,7 +194,7 @@ impl ApplicationHandler<UserEvent> for App {
         }
 
         let mut window_attrs = Window::default_attributes()
-            .with_title("seance")
+            .with_title("séance")
             .with_decorations(self.config.window.decoration);
         if let Some(size) = initial_window_size_from_env() {
             window_attrs = window_attrs.with_inner_size(size);

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,42 @@
+# Naming: `séance` vs `seance`
+
+The project brand carries an acute accent — `séance` — but a non-ASCII byte in a
+`$PATH`-resolved binary name or a reverse-DNS bundle identifier breaks shells,
+package managers, and other tooling. So the surfaces are split: the `é` lives in
+human-facing **display strings**, and plain ASCII `seance` is used everywhere a
+string is an **identifier** that software parses.
+
+## Rule
+
+**Display strings → `séance` / `Séance`.** Anything a person reads as the
+product name:
+
+- README title and release notes.
+- macOS `CFBundleName` and `CFBundleDisplayName` (dock tile, menu bar).
+- The default window title.
+- Homebrew `desc`, AUR `pkgdesc`, Debian `Description`.
+
+**Identifiers → `seance` (ASCII).** Anything software resolves, parses, or keys
+on:
+
+- The binary name (`seance`) and `CFBundleExecutable`.
+- Crate names (`seance-app`, `seance-vt`, …).
+- `CFBundleIdentifier` (`dev.seance.app`).
+- Package names (`brew`, `pacman`, `apt`).
+- The config directory (`$XDG_CONFIG_HOME/seance/`).
+- Environment variables (`SEANCE_*`).
+- The repository slug and branch prefixes.
+
+## On-disk file names
+
+App-bundle and artifact file names stay ASCII even though they name a display
+artifact, so paths remain typeable and copy-pasteable in a shell. The macOS
+bundle is `target/Seance.app` on disk (keeping `open target/Seance.app`
+working), while its `CFBundleDisplayName` inside `Info.plist` is `Séance`.
+
+## Enforcement
+
+`tools/check-naming.sh` greps the tracked display surfaces for the ASCII
+`Seance` spelling where `Séance` belongs (ignoring the allowed `Seance.app` file
+name) and fails if any drift is reintroduced. CI runs it on every push and pull
+request.

--- a/tools/check-naming.sh
+++ b/tools/check-naming.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforces docs/naming.md: display strings spell the brand "séance"/"Séance",
+# while identifiers and on-disk file names stay ASCII "seance". This guards the
+# display surfaces against the ASCII "Seance" spelling creeping back in. The
+# bundle/artifact file name "Seance.app" is deliberately ASCII and allowed.
+
+cd "$(dirname "$0")/.."
+
+# Capital-S ASCII "Seance" anywhere other than the allowed "Seance.app" file
+# name signals a display string that lost its accent.
+if hits=$(grep -RIn 'Seance' -- crates tools README.md CLAUDE.md docs \
+  | grep -v 'Seance\.app' \
+  | grep -v 'tools/check-naming.sh' \
+  | grep -v 'docs/naming.md'); then
+  echo "naming check failed: 'Seance' should be 'Séance' in display strings" >&2
+  echo "(the only allowed ASCII 'Seance' is the 'Seance.app' bundle file name)" >&2
+  echo "$hits" >&2
+  exit 1
+fi
+
+echo "naming check passed"

--- a/tools/make-app.sh
+++ b/tools/make-app.sh
@@ -31,8 +31,8 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
   <key>CFBundleIdentifier</key><string>dev.seance.app</string>
-  <key>CFBundleName</key><string>Seance</string>
-  <key>CFBundleDisplayName</key><string>Seance</string>
+  <key>CFBundleName</key><string>Séance</string>
+  <key>CFBundleDisplayName</key><string>Séance</string>
   <key>CFBundleExecutable</key><string>seance</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>


### PR DESCRIPTION
The brand carries an acute accent — `séance` — but a non-ASCII byte in a `$PATH`-resolved binary name or a reverse-DNS bundle identifier breaks shells, package managers, and other tooling. This settles where the `é` belongs and fixes the spots that had drifted, per Epic M9 (#152).

The rule, now written down in `docs/naming.md`: display strings (anything a person reads as the product name) spell `séance`/`Séance`, while identifiers and on-disk file names that software parses stay ASCII `seance`.

Changes:

- `docs/naming.md` records the rule, the rationale, and the on-disk file-name carve-out (the macOS bundle stays `target/Seance.app` so `open target/Seance.app` remains typeable). Linked from the README's Docs section.
- `CLAUDE.md` H1 and the macOS `CFBundleName`/`CFBundleDisplayName` switch to `Séance`. `CFBundleIdentifier` (`dev.seance.app`), `CFBundleExecutable` (`seance`), and the `Seance.app` bundle path stay ASCII.
- The default window title in `seance-app` becomes `séance`.
- `tools/check-naming.sh` greps the tracked display surfaces (`crates`, `tools`, `README.md`, `CLAUDE.md`, `docs`) for the ASCII `Seance` spelling, allowing only the `Seance.app` file name, and runs as a new `naming` CI job so the drift can't come back.

The audit of `tools/fidelity/*.sh` from the issue checklist is a no-op — that directory does not exist in the tree.

The script is placed at `tools/check-naming.sh` rather than the `scripts/check-naming.sh` path named in the issue, because every dev script in this repo lives under `tools/`; the CI job points at the actual path.

Verification: `tools/check-naming.sh` passes on the cleaned tree and fails when ASCII `Seance` drift is reintroduced (confirmed with a temporary injection). `prettier --check` and `markdownlint-cli2` pass over all `**/*.md`. The one-line `seance-app` window-title change could not be compiled in this Linux container because `libghostty-vt-sys` needs `zig`, so that crate's build/clippy/test ride on CI.

Closes #153

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmRidnFCWw9bPDTXs2uT8p)_