### PR TITLE
docs(naming): codify séance vs seance rule and fix drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
           node-version: "22"
       - run: npx --yes prettier --check "**/*.md"
 
+  naming:
+    name: naming
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: scripts/check-naming.sh
+
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# seance
+# séance
 
 GPU-rendered terminal built on `libghostty-vt` (the Rust bindings from
 [libghostty-rs](https://github.com/Uzaaft/libghostty-rs)) and `wgpu`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ tools/run.sh                 # build and launch
 
 - Architecture & subsystem status:
   [`docs/architecture.md`](docs/architecture.md)
+- Naming (`séance` vs `seance`): [`docs/naming.md`](docs/naming.md)
 - Roadmap: GitHub epics M1–M11 (`label:epic`)
 
 ## License

--- a/crates/seance-app/src/app.rs
+++ b/crates/seance-app/src/app.rs
@@ -194,7 +194,7 @@ impl ApplicationHandler<UserEvent> for App {
         }
 
         let mut window_attrs = Window::default_attributes()
-            .with_title("seance")
+            .with_title("séance")
             .with_decorations(self.config.window.decoration);
         if let Some(size) = initial_window_size_from_env() {
             window_attrs = window_attrs.with_inner_size(size);

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,32 @@
+# Naming: `séance` vs `seance`
+
+Two surfaces, two spellings. Pick by whether a human reads the string or a
+machine resolves it.
+
+## Rule
+
+- **Display strings → `séance` / `Séance`.** Anything a person sees: the README
+  title, release notes, the macOS `CFBundleDisplayName` / `CFBundleName`, the
+  default window title, the dock tile, the menu bar, the Homebrew `desc`, the
+  AUR `pkgdesc`, the Debian `Description`.
+- **Identifiers → `seance` (ASCII).** Anything a tool resolves: the binary name,
+  crate names, `CFBundleIdentifier` (`dev.seance.app`), package names (`brew`,
+  `pacman`, `apt`), the config dir (`$XDG_CONFIG_HOME/seance/`), environment
+  variables (`SEANCE_*`), the repo slug, and the branch prefix.
+
+The `é` is load-bearing for the brand, so display copy keeps it. But non-ASCII
+in a `$PATH`-resolved binary name or a reverse-DNS bundle ID breaks shells and
+tooling, so identifiers stay ASCII. The two surfaces never share a string.
+
+## Bundle filename
+
+The macOS bundle on disk is `target/Seance.app` — an ASCII filename with a
+capital `S` so `open target/Seance.app` stays typeable. This is the one
+sanctioned ASCII `Seance`; the display name inside the bundle
+(`CFBundleDisplayName`) is still `Séance`.
+
+## Enforcement
+
+`scripts/check-naming.sh` greps the tracked source for an ASCII capital-`S`
+`Seance` outside the `Seance.app` bundle filename and fails if it finds one. CI
+runs it on every push and pull request.

--- a/scripts/check-naming.sh
+++ b/scripts/check-naming.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Naming guard. See docs/naming.md.
+#
+# Display surfaces spell the brand "séance" / "Séance"; identifiers stay ASCII
+# "seance". The only sanctioned ASCII capital-S spelling is the macOS bundle
+# filename "Seance.app", so flag any other "Seance".
+
+cd "$(dirname "$0")/.."
+
+# Capital-S "Seance" not immediately followed by ".app".
+if hits=$(grep -RInP 'Seance(?!\.app)' -- crates tools README.md CLAUDE.md 2>/dev/null); then
+  echo "naming: found ASCII 'Seance' where 'Séance' (display) or 'seance'" >&2
+  echo "(identifier) is expected. See docs/naming.md." >&2
+  echo >&2
+  echo "$hits" >&2
+  exit 1
+fi
+
+echo "naming: ok"

--- a/tools/make-app.sh
+++ b/tools/make-app.sh
@@ -31,8 +31,8 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
   <key>CFBundleIdentifier</key><string>dev.seance.app</string>
-  <key>CFBundleName</key><string>Seance</string>
-  <key>CFBundleDisplayName</key><string>Seance</string>
+  <key>CFBundleName</key><string>Séance</string>
+  <key>CFBundleDisplayName</key><string>Séance</string>
   <key>CFBundleExecutable</key><string>seance</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>


### PR DESCRIPTION
Settles where the brand is spelled `séance` / `Séance` versus the ASCII `seance`, codifies it in `docs/naming.md`, and fixes the spots that had drifted — so display surfaces and machine identifiers never share a string.

The `é` is load-bearing for the brand, so display copy keeps the accent. But non-ASCII in a `$PATH`-resolved binary name or a reverse-DNS bundle ID breaks shells and tooling, so identifiers stay ASCII. Splitting the surfaces lets both be correct.

## Changes

- Add `docs/naming.md` with the rule plus a short rationale, and link it from `README.md`.
- `CLAUDE.md` H1 is now `# séance`, matching the README title.
- `tools/make-app.sh`: `CFBundleName` and `CFBundleDisplayName` become `Séance`. `CFBundleIdentifier` (`dev.seance.app`), `CFBundleExecutable` (`seance`), and the on-disk `target/Seance.app` filename stay ASCII.
- The default window title in `seance-app` is now `séance`.
- Add `scripts/check-naming.sh`, which fails on any ASCII capital-`S` `Seance` outside the sanctioned `Seance.app` bundle filename, wired into CI as a new `naming` job.

## Verification

- `scripts/check-naming.sh` passes; a stray `"Seance"` probe is caught and reported.
- `grep -RIn 'Seance' -- crates tools README.md CLAUDE.md` returns only the expected `Seance.app` filename hits in `make-app.sh` and `run.sh`.
- `prettier --check "**/*.md"`, `markdownlint-cli2 "**/*.md"`, and `cargo fmt --all -- --check` are clean.

The only exit-criterion item not exercisable here is the macOS dock showing `Séance` after `tools/run.sh`, since this routine runs headless on Linux; the `Info.plist` keys that drive it are set correctly.

Closes #153

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ8jgfYtCEsEPfRx1Q9obi)_