### PR TITLE
fix(renderer): straddle bar cursor over the left cell edge

### DIFF
--- a/crates/seance-render/src/gpu/shaders/cell.wgsl
+++ b/crates/seance-render/src/gpu/shaders/cell.wgsl
@@ -205,20 +205,33 @@ fn fs_cell_bg(in: FullScreenOut) -> @location(0) vec4<f32> {
 
     if uniforms.cursor_visible != 0u
        && uniforms.overlay_shape != 0u
-       && col == uniforms.overlay_pos.x
        && row == uniforms.overlay_pos.y {
         let local = pos - uniforms.cell_size * vec2<f32>(f32(col), f32(row));
         let cur_color = uniforms.overlay_color;
         var draw = false;
 
-        if uniforms.overlay_shape == 1u {
-            draw = true;
-        } else if uniforms.overlay_shape == 2u {
-            let thickness = max(2.0, uniforms.cell_size.y * 0.12);
-            draw = local.y >= (uniforms.cell_size.y - thickness);
-        } else if uniforms.overlay_shape == 3u {
+        if col == uniforms.overlay_pos.x {
+            if uniforms.overlay_shape == 1u {
+                draw = true;
+            } else if uniforms.overlay_shape == 2u {
+                let thickness = max(2.0, uniforms.cell_size.y * 0.12);
+                draw = local.y >= (uniforms.cell_size.y - thickness);
+            } else if uniforms.overlay_shape == 3u {
+                // Bar straddles the left cell edge; the right half (biased
+                // narrower) falls inside the cursor cell.
+                let thickness = max(2.0, uniforms.cell_size.x * 0.1);
+                let right_half = floor(thickness * 0.5);
+                draw = local.x < right_half;
+            }
+        } else if uniforms.overlay_shape == 3u
+               && uniforms.overlay_pos.x > 0u
+               && col == uniforms.overlay_pos.x - 1u {
+            // Left half of the bar reaches into the preceding cell, so the
+            // bar sits centered between characters rather than biased right.
+            // Bias an extra pixel left to match ghostty's cursor_bar.
             let thickness = max(2.0, uniforms.cell_size.x * 0.1);
-            draw = local.x < thickness;
+            let left_half = ceil(thickness * 0.5);
+            draw = local.x >= (uniforms.cell_size.x - left_half);
         }
 
         if draw {


### PR DESCRIPTION
The bar cursor sat entirely inside the cursor cell at a fixed 10% of cell width, biasing it to the right of the character boundary. Ghostty places the bar centered on the left cell edge (`src/font/sprite/draw/special.zig`'s `cursor_bar`) so it reads as sitting between characters rather than glued to one side.

This splits the bar overlay in `cell.wgsl`'s `fs_cell_bg` across the boundary: the cursor cell draws the right half (`floor(thickness/2)`) and the preceding cell draws the left half (`ceil(thickness/2)`), with the rounding biasing one pixel left to match ghostty's intent. The fullscreen overlay gate now also admits `col == overlay_pos.x - 1` for the bar shape, guarded against the column-0 case where there is no preceding cell to straddle into (the left half is simply clipped there). Block and underline shapes are untouched — they remain confined to the cursor cell.

The WGSL change is sub-pixel and not observable through the layered ASCII-dump harness, so there is no GPU pixel test seam to extend; the shader was validated through naga (`wgsl-in`) parse + full validation, and `cargo test -p seance-render` stays green.

Closes #182

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mkr2JVwCX7Au5yoh4RCNtd)_